### PR TITLE
Add basic variant and callset searching

### DIFF
--- a/testutils.js
+++ b/testutils.js
@@ -54,9 +54,16 @@ function assertField(runner, fieldValue, fieldName, fieldType) {
       // Longs in json are typically formatted as strings,
       // yet should be parseable as numbers
       test = !_.isNaN(parseInt(fieldValue));
+
     } else if (fieldType == 'array') {
       // typeof doesn't work on arrays
       test = _.isArray(fieldValue);
+
+    } else if (fieldType == 'keyvalue') {
+      // This is the json version of the GAKeyValue object
+      test = _.isObject(fieldValue) && _.every(fieldValue, function(v, k) {
+        return typeof v == 'string' && typeof k == 'string';
+      });
 
     } else {
       if (fieldType == 'int' || fieldType == 'float') {


### PR DESCRIPTION
This relies on adding the variantsets/search method
(https://github.com/ga4gh/schemas/pull/134)

Also adds ‘keyvalue’ as a type for easy testing (as pretty much all of
our objects have that field)
