### PR TITLE
Update compliance tests to v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a work in progress, see [this issue](https://github.com/ga4gh/schemas/is
 
 * Run a simple HTTP server locally using python:
   ```
-  cd api-client-javascript
+  cd compliance
   python -m SimpleHTTPServer 8000
   ```
 

--- a/testutils.js
+++ b/testutils.js
@@ -88,7 +88,7 @@ function assertFieldType(runner, fieldValue, fieldName, fieldType) {
     } else if (fieldType == 'keyvalue') {
       // This is the json version of the GAKeyValue object
       test = _.isObject(fieldValue) && _.every(fieldValue, function(v, k) {
-        return typeof v == 'string' && typeof k == 'string';
+        return _.isArray(v) && typeof v[0] == 'string' && typeof k == 'string';
       });
 
     } else {

--- a/v0.1tests.js
+++ b/v0.1tests.js
@@ -122,13 +122,9 @@ registerTest(
           ['templateLength', 'int'],
           'originalBases',
           'alignedBases',
-          'baseQuality'
+          'baseQuality',
+          ['tags', 'keyvalue']
         ]);
-
-        var read = _.first(json.reads) || {};
-        assert(runner, _.every(read.tags, function(value, key) {
-          return typeof key == 'string' && typeof value[0] == 'string';
-        }), 'Field reads.tags is a map from string to array of strings');
 
         runner.testFinished();
       });


### PR DESCRIPTION
Also fills in some more test cases. The variant and read related methods are covered pretty well now, reference methods need some work mostly because there are no known implementations to test against right now.
