### PR TITLE
Possible Maven build fix; doc updates; new tests; bug fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+jdk:
+- oraclejdk8
+deploy:
+  provider: releases
+  api_key:
+    secure: Ly7MPzmxaRv9U46WzvGj/MxI4CvEY4uExvh88K9Hinj2XSUzuLKfLJ0yKs1Dg0VJLSqKIraRMt3aFTuYIPCBxcqbrK1kTTU+DtxqoBDHVhnvbxX0uMpSnwmizZFutmi2NpmsshiRkHsXUfc8UeLaP2eFp9YcmyixTybDYAifwO0=
+  file: dist/target/ga4gh-ctk-cli.zip
+  skip_cleanup: true
+  on:
+    repo: ga4gh/compliance
+    tags: true
+

--- a/ctk-domain/src/main/assertj-assertions/org/ga4gh/methods/SearchVariantsRequestAssert.java
+++ b/ctk-domain/src/main/assertj-assertions/org/ga4gh/methods/SearchVariantsRequestAssert.java
@@ -272,29 +272,6 @@ public class SearchVariantsRequestAssert extends AbstractAssert<SearchVariantsRe
   }
 
   /**
-   * Verifies that the actual SearchVariantsRequest's variantName is equal to the given one.
-   * @param variantName the given variantName to compare the actual SearchVariantsRequest's variantName to.
-   * @return this assertion object.
-   * @throws AssertionError - if the actual SearchVariantsRequest's variantName is not equal to the given one.
-   */
-  public SearchVariantsRequestAssert hasVariantName(String variantName) {
-    // check that actual SearchVariantsRequest we want to make assertions on is not null.
-    isNotNull();
-
-    // overrides the default error message with a more explicit one
-    String assertjErrorMessage = "\nExpecting variantName of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
-    
-    // null safe check
-    String actualVariantName = actual.getVariantName();
-    if (!Objects.areEqual(actualVariantName, variantName)) {
-      failWithMessage(assertjErrorMessage, actual, variantName, actualVariantName);
-    }
-
-    // return the current assertion for method chaining
-    return this;
-  }
-
-  /**
    * Verifies that the actual SearchVariantsRequest's variantSetId is equal to the given one.
    * @param variantSetId the given variantSetId to compare the actual SearchVariantsRequest's variantSetId to.
    * @return this assertion object.
@@ -316,7 +293,6 @@ public class SearchVariantsRequestAssert extends AbstractAssert<SearchVariantsRe
     // return the current assertion for method chaining
     return this;
   }
-
 
 
 

--- a/ctk-schemas/src/main/resources/avro/variantmethods.avdl
+++ b/ctk-schemas/src/main/resources/avro/variantmethods.avdl
@@ -70,12 +70,6 @@ record SearchVariantsRequest {
   string variantSetId;
 
   /**
-  Only return variants which have exactly this name (case-sensitive, exact
-  match).
-  */
-  union { null, string } variantName = null;
-
-  /**
   Only return variant calls which belong to call sets with these IDs.
   If an empty array, returns variants without any call objects.
   If null, returns all variant calls.

--- a/ctk-testrunner/pom.xml
+++ b/ctk-testrunner/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk-testrunner</artifactId>
-    <version>0.6.0-PRE</version>
+    <version>0.5.1-SNAPSHOT</version>
     <name>CTK Test Runner</name>
     <description>Test-running module (not self-executable, requires a launcher)</description>
     <parent>

--- a/ctk-testrunner/src/main/java/org/ga4gh/ctk/AntExecutor.java
+++ b/ctk-testrunner/src/main/java/org/ga4gh/ctk/AntExecutor.java
@@ -6,14 +6,15 @@ package org.ga4gh.ctk;
  */
 
 import org.apache.tools.ant.*;
-import org.ga4gh.ctk.config.*;
-import org.ga4gh.ctk.transport.*;
-import org.springframework.beans.factory.annotation.*;
+import org.ga4gh.ctk.config.Props;
+import org.ga4gh.ctk.transport.URLMAPPING;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.*;
+import org.springframework.stereotype.Component;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.util.Properties;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -119,7 +120,7 @@ public class AntExecutor {
         Project project = new Project();
         try {
             File buildFile = antFile;
-            project.setUserProperty("basedir",System.getProperty("user.dir"));
+            project.setUserProperty("basedir", System.getProperty("user.dir"));
             project.setUserProperty("ant.file", buildFile.getName());
             project.setUserProperty("ctk.testjar", testjar);
             project.setUserProperty("ctk.matchstr", matchstr);
@@ -127,8 +128,9 @@ public class AntExecutor {
             project.setUserProperty("ctk.todir", toDir);
             project.addBuildListener(antExecListener);
             // if there's an interested listener, hook them up
-            if(theBoss != null)
+            if (theBoss != null) {
                 project.addBuildListener(theBoss);
+            }
 
             project.fireBuildStarted();
             project.init();

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
@@ -234,6 +234,8 @@ public class AvroJson<Q extends SpecificRecordBase, P extends SpecificRecordBase
             String json = httpResp.getBody().toString();
 
             theResp = new AvroMaker<>(theResp).makeAvroFromJson(json, urlRoot + path); // URL just for logging
+        } else {
+            theResp = null;
         }
         // track all message types sent/received for simple "test coverage" indication
         String respName = theResp != null ? theResp.getClass().getSimpleName()  : "null";
@@ -274,7 +276,7 @@ public class AvroJson<Q extends SpecificRecordBase, P extends SpecificRecordBase
     public P doGetResp(String id, Map<String, Object> queryParams) {
 
         // no request object to build, just GET from the endpoint with route param
-        httpResp = shouldDoComms? jsonGet(urlRoot + path, id, queryParams) : NO_COMM_RESP;
+        httpResp = shouldDoComms ? jsonGet(urlRoot + path, id, queryParams) : NO_COMM_RESP;
 
         updateTheRespAndLogMessages("GET");
 

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
@@ -179,7 +179,7 @@ public class Client {
         }
 
         /**
-         * Gets a list of {@link CallSet} matching the search criteria.
+         * Gets a list of {@link CallSet}s matching the search criteria.
          * <p>
          * <tt>POST /callsets/search</tt> accepts a {@link SearchCallSetsRequest}
          * and returns a {@link SearchCallSetsResponse}.

--- a/ctk-transport/src/test/java/org/ga4gh/ctk/transport/avrojson/JsonMakerTest.java
+++ b/ctk-transport/src/test/java/org/ga4gh/ctk/transport/avrojson/JsonMakerTest.java
@@ -140,12 +140,10 @@ public class JsonMakerTest {
                 .setStart(500L)
                 .setEnd(7654L)
                 .setPageToken("snuffle.bunny")
-                .setVariantName("garble")
                 .setVariantSetId("great_variant_set_id")
                 .build();
         String actual = JsonMaker.GsonToJsonBytes(svr);
 
-        JSONAssert.assertEquals("{variantName:garble}", actual, false);
         JSONAssert.assertEquals("{referenceName:I.Am.The.Walrus}", actual, false);
         JSONAssert.assertEquals("{callSetIds:[\"foo\", \"bar\"]}", actual, false);
         JSONAssert.assertEquals("{callSetIds:[\"bar\", \"foo\"]}", actual, false);

--- a/cts-java/pom.xml
+++ b/cts-java/pom.xml
@@ -190,6 +190,14 @@
                     </reportSet>
                 </reportSets>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.3</version>
+                <configuration>
+                    <destDir>api_docs</destDir>
+                </configuration>
+            </plugin>
         </plugins>
     </reporting>
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/DatasetIdPropertyIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/DatasetIdPropertyIT.java
@@ -1,0 +1,66 @@
+package org.ga4gh.cts.api;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests to make sure we can override the ID of the compliance test dataset.
+ *
+ * @author Herb Jellinek
+ */
+public class DatasetIdPropertyIT {
+
+    private static final String PROP_NAME = "cfg.tgt.dataset_id";
+
+    /**
+     * Check that {@link TestData#getDatasetId()} returns the default dataset ID when
+     * there's no overriding value in the Java {@link System} properties.
+     */
+    @Test
+    public void checkDefaultValue() {
+        final String originalValue = System.getProperty(PROP_NAME);
+        try {
+            System.clearProperty(PROP_NAME);
+            assertThat(System.getProperty(PROP_NAME)).isNull();
+
+            // the real test:
+            assertThat(TestData.getDatasetId()).isEqualTo(TestData.DEFAULT_DATASET_ID);
+
+        } finally {
+            // the system properties are a global resource, so clean up
+            if (originalValue == null) {
+                System.clearProperty(PROP_NAME);
+            } else {
+                System.setProperty("cfg.tgt.dataset_id", originalValue);
+            }
+        }
+    }
+
+    /**
+     * Check that {@link TestData#getDatasetId()} returns the override dataset ID when
+     * there's an overriding value in the Java {@link System} properties.
+     */
+    @Test
+    public void checkOverrideValue() {
+        final String originalValue = System.getProperty(PROP_NAME);
+        try {
+            final String madeUpId = Utils.randomId();
+
+            System.setProperty(PROP_NAME, madeUpId);
+            assertThat(System.getProperty(PROP_NAME)).isEqualTo(madeUpId);
+
+            // the real test:
+            assertThat(TestData.getDatasetId()).isEqualTo(madeUpId);
+
+        } finally {
+            // the system properties are a global resource, so clean up
+            if (originalValue == null) {
+                System.clearProperty(PROP_NAME);
+            } else {
+                System.setProperty("cfg.tgt.dataset_id", originalValue);
+            }
+        }
+    }
+
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -18,12 +18,18 @@ public class TestData {
     }
 
     /**
-     * The ID of the dataset that holds the test data.
+     * The default ID of the dataset that holds the test data.
      */
-    public static final String DATASET_ID = "compliance-dataset1";
+    public static final String DEFAULT_DATASET_ID = "compliance-dataset1";
 
     /**
-     * The names of the readgroup sets in {@link #DATASET_ID}.
+     * The name of the Java system property that sets the name of the compliance dataset,
+     * if the default (<tt>compliance-dataset1</tt>) is not correct.
+     */
+    private static final String DATASET_PROP_NAME = "cfg.tgt.dataset_id";
+
+    /**
+     * The names of the readgroup sets in the standard compliance dataset.
      */
     public static final String[] EXPECTED_READGROUPSETS_NAMES = {
             "compliance-dataset1:1kg-low-coverage",
@@ -54,5 +60,19 @@ public class TestData {
     public static final String[] EXPECTED_REFERENCE_NAMES = {
             "example_1:simple",
     };
+
+    /**
+     * Return the ID of the compliance dataset on the server being tested.
+     * By default this is the value of {@link #DEFAULT_DATASET_ID}, <tt>compliance-dataset1</tt>, but
+     * it can be overridden by setting the Java property <tt>-Dcfg.tgt.dataset_id</tt>.
+     */
+    public static String getDatasetId() {
+        final String propValue = System.getProperty(DATASET_PROP_NAME);
+        if (propValue != null) {
+            return propValue;
+        } else {
+            return DEFAULT_DATASET_ID;
+        }
+    }
 
 }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
@@ -37,15 +37,15 @@ public class DatasetsSearchIT {
 
         final Dataset dataset = datasets.get(0);
         assertThat(dataset).isNotNull();
-        assertThat(dataset.getId()).isEqualTo(TestData.DATASET_ID);
+        assertThat(dataset.getId()).isEqualTo(TestData.getDatasetId());
     }
 
     @Test
     @Ignore("The server doesn't implement GET /datasets/{id} yet")
     public void fetchDatasetByName() throws AvroRemoteException {
-        final Dataset dataset = client.reads.getDataset(TestData.DATASET_ID);
+        final Dataset dataset = client.reads.getDataset(TestData.getDatasetId());
         assertThat(dataset).isNotNull();
-        assertThat(dataset.getId()).isEqualTo(TestData.DATASET_ID);
+        assertThat(dataset.getId()).isEqualTo(TestData.getDatasetId());
     }
 
     @Test

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
@@ -1,0 +1,46 @@
+package org.ga4gh.cts.api.reads;
+
+import org.apache.avro.AvroRemoteException;
+import org.ga4gh.ctk.transport.URLMAPPING;
+import org.ga4gh.ctk.transport.protocols.Client;
+import org.ga4gh.cts.api.TestData;
+import org.ga4gh.methods.SearchReadGroupSetsRequest;
+import org.ga4gh.methods.SearchReadGroupSetsResponse;
+import org.ga4gh.models.ReadGroupSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the <pre>/readgroups/{id}</pre> endpoint.
+ *
+ * @author Herb Jellinek
+ */
+@Category(ReadsTests.class)
+public class ReadGroupSetsGetByIdIT {
+
+    private static Client client = new Client(URLMAPPING.getInstance());
+
+    @Test
+    public void testGetByIdMatchesSearch() throws AvroRemoteException {
+        final SearchReadGroupSetsRequest request =
+                SearchReadGroupSetsRequest.newBuilder()
+                                          .setDatasetId(TestData.DATASET_ID)
+                                          .build();
+
+        // search for all ReadGroupSets
+        final SearchReadGroupSetsResponse response = client.reads.searchReadGroupSets(request);
+        assertThat(response).isNotNull();
+        assertThat(response.getReadGroupSets()).isNotEmpty();
+
+        // for each one, fetch it by its ID and compare the result to the one we got by searching
+        for (ReadGroupSet fromSearch : response.getReadGroupSets()) {
+            assertThat(fromSearch).isNotNull();
+            final String searchReadGroupSetId = fromSearch.getId();
+            final ReadGroupSet fromGet = client.reads.getReadGroupSet(searchReadGroupSetId);
+            assertThat(fromGet).isEqualTo(fromSearch);
+        }
+    }
+
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
@@ -22,6 +22,12 @@ public class ReadGroupSetsGetByIdIT {
 
     private static Client client = new Client(URLMAPPING.getInstance());
 
+    /**
+     * Check that the {@link ReadGroupSet}s we get via search (1) have valid IDs in them; (2)
+     * those IDs can be used to fetch identical {@link ReadGroupSet}s.
+     *
+     * @throws AvroRemoteException if there's a communication problem
+     */
     @Test
     public void testGetByIdMatchesSearch() throws AvroRemoteException {
         final SearchReadGroupSetsRequest request =

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
@@ -32,7 +32,7 @@ public class ReadGroupSetsGetByIdIT {
     public void testGetByIdMatchesSearch() throws AvroRemoteException {
         final SearchReadGroupSetsRequest request =
                 SearchReadGroupSetsRequest.newBuilder()
-                                          .setDatasetId(TestData.DATASET_ID)
+                                          .setDatasetId(TestData.getDatasetId())
                                           .build();
 
         // search for all ReadGroupSets

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsSearchIT.java
@@ -97,9 +97,9 @@ public class ReadGroupSetsSearchIT implements CtkLogs {
     @Test
     public void readgroupSetResponseForNonexistentDatasetIdShouldReturnEmptyList() throws AvroRemoteException {
         SearchReadGroupSetsRequest reqb =
-                SearchReadGroupSetsRequest.newBuilder().
-                        setDatasetId(BAD_DATASET_ID).
-                        build();
+                SearchReadGroupSetsRequest.newBuilder()
+                                          .setDatasetId(BAD_DATASET_ID)
+                                          .build();
         SearchReadGroupSetsResponse rtnVal = client.reads.searchReadGroupSets(reqb);
         // avro says always get a 200
         SearchReadGroupSetsResponseAssert.assertThat(rtnVal).isNotNull().hasNoReadGroupSets();

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsSearchIT.java
@@ -59,7 +59,7 @@ public class ReadGroupSetsSearchIT implements CtkLogs {
         for (String rgSetName : TestData.EXPECTED_READGROUPSETS_NAMES) {
             final SearchReadGroupSetsRequest goodReq =
                     SearchReadGroupSetsRequest.newBuilder().
-                            setDatasetId(TestData.DATASET_ID).setName(rgSetName).build();
+                            setDatasetId(TestData.getDatasetId()).setName(rgSetName).build();
             SearchReadGroupSetsResponse goodResp = client.reads.searchReadGroupSets(goodReq);
             final List<ReadGroupSet> rgSets = goodResp.getReadGroupSets();
             assertThat(rgSets).hasSize(1);
@@ -80,7 +80,7 @@ public class ReadGroupSetsSearchIT implements CtkLogs {
         // try to fetch a read group set with a name the server can't match
         final SearchReadGroupSetsRequest badReq =
                 SearchReadGroupSetsRequest.newBuilder().
-                        setDatasetId(TestData.DATASET_ID).setName(BAD_READGROUPSET_NAME).build();
+                        setDatasetId(TestData.getDatasetId()).setName(BAD_READGROUPSET_NAME).build();
         SearchReadGroupSetsResponse badResp = client.reads.searchReadGroupSets(badReq);
         final List<ReadGroupSet> emptyRgSets = badResp.getReadGroupSets();
         assertThat(emptyRgSets).isEmpty();
@@ -121,16 +121,16 @@ public class ReadGroupSetsSearchIT implements CtkLogs {
     public void requestForAllReadGroupSetsShouldReturnAllWellFormed() throws AvroRemoteException {
         final SearchReadGroupSetsRequest req =
                 SearchReadGroupSetsRequest.newBuilder()
-                                          .setDatasetId(TestData.DATASET_ID)
+                                          .setDatasetId(TestData.getDatasetId())
                                           .build();
         final SearchReadGroupSetsResponse resp = client.reads.searchReadGroupSets(req);
         final List<ReadGroupSet> readGroupSets = resp.getReadGroupSets();
-        readGroupSets.stream().forEach(rgs -> assertThat(rgs.getDatasetId()).isEqualTo(TestData.DATASET_ID));
+        readGroupSets.stream().forEach(rgs -> assertThat(rgs.getDatasetId()).isEqualTo(TestData.getDatasetId()));
 
         for (ReadGroupSet readGroupSet : readGroupSets) {
             for (ReadGroup readGroup : readGroupSet.getReadGroups()) {
                 assertThat(readGroup).isNotNull();
-                assertThat(readGroup.getDatasetId()).isEqualTo(TestData.DATASET_ID);
+                assertThat(readGroup.getDatasetId()).isEqualTo(TestData.getDatasetId());
                 assertThat(readGroup.getPrograms()).isNotEmpty();
                 assertThat(readGroup.getPrograms()).doesNotContain(Utils.nullProgram);
             }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
@@ -23,6 +23,12 @@ public class ReadGroupsGetByIdIT {
 
     private static Client client = new Client(URLMAPPING.getInstance());
 
+    /**
+     * Check that the {@link ReadGroup}s we get via search (1) have valid IDs in them; (2)
+     * those IDs can be used to fetch identical {@link ReadGroup}s.
+     *
+     * @throws AvroRemoteException if there's a communication problem
+     */
     @Test
     public void testGetByIdMatchesSearch() throws AvroRemoteException {
         final SearchReadGroupSetsRequest request =

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
@@ -33,7 +33,7 @@ public class ReadGroupsGetByIdIT {
     public void testGetByIdMatchesSearch() throws AvroRemoteException {
         final SearchReadGroupSetsRequest request =
                 SearchReadGroupSetsRequest.newBuilder()
-                                          .setDatasetId(TestData.DATASET_ID)
+                                          .setDatasetId(TestData.getDatasetId())
                                           .build();
 
         // search for all ReadGroupSets

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
@@ -1,0 +1,52 @@
+package org.ga4gh.cts.api.reads;
+
+import org.apache.avro.AvroRemoteException;
+import org.ga4gh.ctk.transport.URLMAPPING;
+import org.ga4gh.ctk.transport.protocols.Client;
+import org.ga4gh.cts.api.TestData;
+import org.ga4gh.methods.SearchReadGroupSetsRequest;
+import org.ga4gh.methods.SearchReadGroupSetsResponse;
+import org.ga4gh.models.ReadGroup;
+import org.ga4gh.models.ReadGroupSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the <pre>/readgroups/{id}</pre> endpoint.
+ *
+ * @author Herb Jellinek
+ */
+@Category(ReadsTests.class)
+public class ReadGroupsGetByIdIT {
+
+    private static Client client = new Client(URLMAPPING.getInstance());
+
+    @Test
+    public void testGetByIdMatchesSearch() throws AvroRemoteException {
+        final SearchReadGroupSetsRequest request =
+                SearchReadGroupSetsRequest.newBuilder()
+                                          .setDatasetId(TestData.DATASET_ID)
+                                          .build();
+
+        // search for all ReadGroupSets
+        final SearchReadGroupSetsResponse response = client.reads.searchReadGroupSets(request);
+        assertThat(response).isNotNull();
+        assertThat(response.getReadGroupSets()).isNotEmpty();
+
+        // for each one, fetch its ReadGroups and compare the result to the one we got by searching
+        for (ReadGroupSet readGroupSets : response.getReadGroupSets()) {
+            assertThat(readGroupSets).isNotNull();
+
+            for (ReadGroup readGroupFromSearch : readGroupSets.getReadGroups()) {
+                assertThat(readGroupFromSearch).isNotNull();
+                final String searchReadGroupId = readGroupFromSearch.getId();
+                final ReadGroup readGroupFromGet = client.reads.getReadGroup(searchReadGroupId);
+
+                assertThat(readGroupFromGet).isEqualTo(readGroupFromSearch);
+            }
+        }
+    }
+
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
@@ -61,7 +61,7 @@ public class ReadsSearchIT implements CtkLogs {
 
         final SearchReadGroupSetsRequest req =
                 SearchReadGroupSetsRequest.newBuilder()
-                                          .setDatasetId(TestData.DATASET_ID)
+                                          .setDatasetId(TestData.getDatasetId())
                                           .setName(expectedReadGroupSetName)
                                           .build();
         final SearchReadGroupSetsResponse resp = client.reads.searchReadGroupSets(req);

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -140,7 +140,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
     public void searchForExpectedCallSets() throws AvroRemoteException {
         final SearchVariantSetsRequest vReq =
                 SearchVariantSetsRequest.newBuilder()
-                                        .setDatasetId(TestData.DATASET_ID)
+                                        .setDatasetId(TestData.getDatasetId())
                                         .build();
         final SearchVariantSetsResponse vResp = client.variants.searchVariantSets(vReq);
 
@@ -166,7 +166,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
     public void getCallSetWithValidIDShouldSucceed() throws AvroRemoteException {
         final SearchVariantSetsRequest vReq =
                 SearchVariantSetsRequest.newBuilder()
-                                        .setDatasetId(TestData.DATASET_ID)
+                                        .setDatasetId(TestData.getDatasetId())
                                         .build();
         final SearchVariantSetsResponse vResp = client.variants.searchVariantSets(vReq);
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -5,7 +5,6 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.avro.AvroRemoteException;
-import org.assertj.core.api.Assertions;
 import org.ga4gh.ctk.CtkLogs;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
@@ -16,13 +15,15 @@ import org.ga4gh.methods.SearchVariantSetsRequest;
 import org.ga4gh.methods.SearchVariantSetsResponse;
 import org.ga4gh.models.CallSet;
 import org.ga4gh.models.VariantSet;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.net.HttpURLConnection;
+import java.util.UUID;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * <p>
@@ -61,8 +62,11 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
         // send some malformed requests and expect status == HTTP_BAD_REQUEST
         final String[] badJson = {"", "JSON", "<xml/>", "{", "}", "{\"bad:\"", "{]"};
         for (String datum : badJson) {
-            assertThat(Unirest.post(fullUrl).header("Content-type", "application/json").
-                    body(datum).asBinary().getStatus()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+            assertThat(Unirest.post(fullUrl)
+                              .header("Content-type", "application/json")
+                              .body(datum)
+                              .asBinary()
+                              .getStatus()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
         }
     }
 
@@ -141,7 +145,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
                                         .build();
         final SearchVariantSetsResponse vResp = client.variants.searchVariantSets(vReq);
 
-        Assertions.assertThat(vResp.getVariantSets()).isNotEmpty();
+        assertThat(vResp.getVariantSets()).isNotEmpty();
         for (VariantSet set : vResp.getVariantSets()) {
             final String id = set.getId();
 
@@ -151,12 +155,12 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
                                          .build();
             final SearchCallSetsResponse csResp = client.variants.searchCallSets(csReq);
 
-            Assertions.assertThat(csResp.getCallSets()).isNotEmpty();
+            assertThat(csResp.getCallSets()).isNotEmpty();
         }
     }
 
     /**
-     * Test getting a call set by ID.
+     * Test getting a call set with a valid ID.
      * @throws AvroRemoteException if there's a communication problem
      */
     @Test
@@ -167,7 +171,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
                                         .build();
         final SearchVariantSetsResponse vResp = client.variants.searchVariantSets(vReq);
 
-        Assertions.assertThat(vResp.getVariantSets()).isNotEmpty();
+        assertThat(vResp.getVariantSets()).isNotEmpty();
 
         // grab the first VariantSet and use it as source of ReadSets
         final VariantSet variantSet = vResp.getVariantSets().get(0);
@@ -180,7 +184,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
         final SearchCallSetsResponse csResp = client.variants.searchCallSets(callSetsSearchRequest);
 
         // grab one of the CallSets returned from the search
-        Assertions.assertThat(csResp.getCallSets()).isNotEmpty();
+        assertThat(csResp.getCallSets()).isNotEmpty();
         final CallSet callSetFromSearch = csResp.getCallSets().get(0);
         final String callSetId = callSetFromSearch.getId();
         assertThat(callSetId).isNotNull();
@@ -191,5 +195,20 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
         assertThat(callSetFromGet.getId()).isEqualTo(callSetId);
         assertThat(callSetFromGet).isEqualTo(callSetFromSearch);
     }
+
+    /**
+     * Test getting a call set with an invalid ID.
+     * @throws AvroRemoteException if there's a communication problem
+     */
+    @Test
+    @Ignore("Docs don't specify return value of getCallSet(bogusCallSetId)")
+    public void getCallSetWithInvalidIDShouldFail() throws AvroRemoteException {
+        final String bogusCallSetId = UUID.randomUUID().toString();
+
+        // fetch the CallSet with that ID
+        final CallSet callSetFromGet = client.variants.getCallSet(bogusCallSetId);
+        assertThat(callSetFromGet).isNull();
+    }
+
 
 }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -155,4 +155,41 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
         }
     }
 
+    /**
+     * Test getting a call set by ID.
+     * @throws AvroRemoteException if there's a communication problem
+     */
+    @Test
+    public void getCallSetWithValidIDShouldSucceed() throws AvroRemoteException {
+        final SearchVariantSetsRequest vReq =
+                SearchVariantSetsRequest.newBuilder()
+                                        .setDatasetId(TestData.DATASET_ID)
+                                        .build();
+        final SearchVariantSetsResponse vResp = client.variants.searchVariantSets(vReq);
+
+        Assertions.assertThat(vResp.getVariantSets()).isNotEmpty();
+
+        // grab the first VariantSet and use it as source of ReadSets
+        final VariantSet variantSet = vResp.getVariantSets().get(0);
+        final String variantSetId = variantSet.getId();
+
+        final SearchCallSetsRequest callSetsSearchRequest =
+                SearchCallSetsRequest.newBuilder()
+                                     .setVariantSetId(variantSetId)
+                                     .build();
+        final SearchCallSetsResponse csResp = client.variants.searchCallSets(callSetsSearchRequest);
+
+        // grab one of the CallSets returned from the search
+        Assertions.assertThat(csResp.getCallSets()).isNotEmpty();
+        final CallSet callSetFromSearch = csResp.getCallSets().get(0);
+        final String callSetId = callSetFromSearch.getId();
+        assertThat(callSetId).isNotNull();
+
+        // fetch the CallSet with that ID and compare with the one from the search
+        final CallSet callSetFromGet = client.variants.getCallSet(callSetId);
+        assertThat(callSetFromGet).isNotNull();
+        assertThat(callSetFromGet.getId()).isEqualTo(callSetId);
+        assertThat(callSetFromGet).isEqualTo(callSetFromSearch);
+    }
+
 }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -15,7 +15,6 @@ import org.ga4gh.methods.SearchVariantSetsRequest;
 import org.ga4gh.methods.SearchVariantSetsResponse;
 import org.ga4gh.models.CallSet;
 import org.ga4gh.models.VariantSet;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -201,7 +200,6 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
      * @throws AvroRemoteException if there's a communication problem
      */
     @Test
-    @Ignore("Docs don't specify return value of getCallSet(bogusCallSetId)")
     public void getCallSetWithInvalidIDShouldFail() throws AvroRemoteException {
         final String bogusCallSetId = UUID.randomUUID().toString();
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
@@ -43,7 +43,7 @@ public class VariantSetsSearchIT implements CtkLogs {
     @Test
     public void searchVariantSets() throws AvroRemoteException {
         final SearchVariantSetsRequest req =
-                SearchVariantSetsRequest.newBuilder().setDatasetId(TestData.DATASET_ID).build();
+                SearchVariantSetsRequest.newBuilder().setDatasetId(TestData.getDatasetId()).build();
         final SearchVariantSetsResponse resp = client.variants.searchVariantSets(req);
 
         final List<VariantSet> sets = resp.getVariantSets();

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
@@ -6,7 +6,6 @@ import org.ga4gh.ctk.CtkLogs;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
-import org.ga4gh.cts.api.reads.ReadsTests;
 import org.ga4gh.methods.SearchVariantSetsRequest;
 import org.ga4gh.methods.SearchVariantSetsResponse;
 import org.ga4gh.models.VariantSet;
@@ -24,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Herb Jellinek
  */
-@Category(ReadsTests.class)
+@Category(VariantsTests.class)
 @RunWith(JUnitParamsRunner.class)
 public class VariantSetsSearchIT implements CtkLogs {
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
@@ -44,7 +44,7 @@ public class VariantsGetByIdIT {
         // first get a variant set ID
         final SearchVariantSetsRequest searchVariantSetsReq =
                 SearchVariantSetsRequest.newBuilder()
-                                        .setDatasetId(TestData.DATASET_ID)
+                                        .setDatasetId(TestData.getDatasetId())
                                         .build();
         final SearchVariantSetsResponse searchVariantSetsResp =
                 client.variants.searchVariantSets(searchVariantSetsReq);

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
@@ -30,6 +30,11 @@ public class VariantsGetByIdIT {
 
     private static Client client = new Client(URLMAPPING.getInstance());
 
+    /**
+     * Verify that Variants that we obtain by way of {@link SearchVariantsRequest} match the ones
+     * we get via <tt>GET /variants/{id}</tt>.
+     * @throws AvroRemoteException if there's a communication problem
+     */
     @Test
     public void checkVariantsGetResultsMatchSearchResults() throws AvroRemoteException {
         final long start = 60156;

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
@@ -1,0 +1,74 @@
+package org.ga4gh.cts.api.variants;
+
+import junitparams.JUnitParamsRunner;
+import org.apache.avro.AvroRemoteException;
+import org.ga4gh.ctk.transport.URLMAPPING;
+import org.ga4gh.ctk.transport.protocols.Client;
+import org.ga4gh.cts.api.TestData;
+import org.ga4gh.methods.SearchVariantSetsRequest;
+import org.ga4gh.methods.SearchVariantSetsResponse;
+import org.ga4gh.methods.SearchVariantsRequest;
+import org.ga4gh.methods.SearchVariantsResponse;
+import org.ga4gh.models.Variant;
+import org.ga4gh.models.VariantSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <tt>GET /variants/{id}</tt>.
+ *
+ * @author Herb Jellinek
+ */
+@Category(VariantsTests.class)
+@RunWith(JUnitParamsRunner.class)
+public class VariantsGetByIdIT {
+
+    private static Client client = new Client(URLMAPPING.getInstance());
+
+    @Test
+    public void checkVariantsGetResultsMatchSearchResults() throws AvroRemoteException {
+        final long start = 60156;
+        final long end = 60383;
+        final String referenceName = "3";
+
+        // first get a variant set ID
+        final SearchVariantSetsRequest searchVariantSetsReq =
+                SearchVariantSetsRequest.newBuilder()
+                                        .setDatasetId(TestData.DATASET_ID)
+                                        .build();
+        final SearchVariantSetsResponse searchVariantSetsResp =
+                client.variants.searchVariantSets(searchVariantSetsReq);
+
+        final List<VariantSet> variantSets = searchVariantSetsResp.getVariantSets();
+        assertThat(variantSets).isNotEmpty();
+        final String variantSetId = variantSets.get(0).getId();
+
+        // then gather the variants that are part of the VariantSet with that ID
+        final SearchVariantsRequest req =
+                SearchVariantsRequest.newBuilder()
+                                     .setVariantSetId(variantSetId)
+                                     .setReferenceName(referenceName)
+                                     .setStart(start)
+                                     .setEnd(end)
+                                     .build();
+        final SearchVariantsResponse resp = client.variants.searchVariants(req);
+
+        final List<Variant> variants = resp.getVariants();
+        assertThat(variants).isNotEmpty();
+
+        for (final Variant variantFromSearch : variants) {
+            final Variant variantFromGet = client.variants.getVariant(variantFromSearch.getId());
+            assertThat(variantFromGet).isNotNull();
+
+            assertThat(variantFromGet).isEqualTo(variantFromSearch);
+        }
+
+    }
+
+
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsSearchIT.java
@@ -52,7 +52,7 @@ public class VariantsSearchIT implements CtkLogs {
 
         final SearchVariantSetsRequest req =
                 SearchVariantSetsRequest.newBuilder()
-                                        .setDatasetId(TestData.DATASET_ID)
+                                        .setDatasetId(TestData.getDatasetId())
                                         .build();
         final SearchVariantSetsResponse resp = client.variants.searchVariantSets(req);
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,10 +57,13 @@ with Maven test reporting (as, for example, IntelliJ or Eclipse). See the
 
 
 ## Functional Status
-(June 22 2015) The CTK is able to execute and report on tests written in Java against the v0.5.1 schema. The collection of tests is currently small, and only attempts to use the *reads*, *references*, and *variants* endpoints.
-The tests presume the server has been configured with a data set as described in the
-[GA4GH API Demo instructions](http://ga4gh-reference-implementation.readthedocs.org/en/stable/demo.html). A Maven-capable user can generate cross-referenced
-javadoc and source for the framework and for server tests, and for test results.
+(August 1, 2015) The CTK runs against a reference server using the v6.0.be171b00 schemas.
+
+(June 22 2015) The CTK is able to execute and report on tests written in Java against the v0.5.1 schema. The collection of tests is currently small, and only attempts to
+ use the *reads*, *references*, and *variants* endpoints. The tests presume the server has been configured with a data
+ set as described in the [GA4GH API Demo
+ instructions](http://ga4gh-reference-implementation.readthedocs.org/en/stable/demo.html). A Maven-capable user can
+ generate cross-referenced javadoc and source for the framework and for server tests, and for test results.
 
 ## Build Status
 

--- a/docs/RunningTests_CLI.md
+++ b/docs/RunningTests_CLI.md
@@ -18,7 +18,7 @@ When the tests are done, the reports will be in the `target/` directory. There a
 
 so, for example,
 
-    java -jar ctk-cli-0.5.1-SNAPSHOT.jar -Dctk.tgt.urlRoot=http://myserver:8000/v0.5.1
+    java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.tgt.urlRoot=http://myserver:8000/v0.5.1
 
 Tip - if you're regularly testing against the same server, you can set an operating system environment variable "`ctk_tgt_urlRoot`" (or "`ctk.tgt.urlRoot`" if your environment prefers that) to avoid having to re-enter that URL all the time on the command line. How you set environment variables varies with your shell, but a common example would be to add to your ~/.bashrc a line like"
 
@@ -135,7 +135,7 @@ If you want to alter which tests get run, you can do that on the command line
     ...
 ```
 
-To make this work, the CTK/CTS  has a naming convention for tests:
+To make this work, the CTK/CTS has a naming convention for tests:
 
 **Test classes end in "IT"**
 

--- a/docs/WritingATest.md
+++ b/docs/WritingATest.md
@@ -3,17 +3,21 @@
 This covers the mechanics of adding tests to the `cts-java` module.
 
 ## Prerequisites
-- A reachable GA4GH Server; the CTK framework assumes this is available at the URL provided by the `ctk.tgt.urlRoot` property (e.g., `http://192.168.2.115:8000/v0.5.1/`)
+- A reachable GA4GH Server; the CTK framework assumes this is available at the URL provided by the `ctk.tgt.urlRoot`
+property (e.g., `http://192.168.2.115:8000/v0.5.1/`)
 - The CTK source installed (see [Installing The CTK](InstallingTheCTK.md))
 - You're familiar with the [CTK Test Architecture and Conventions](TestArchAndConventions.md)
 
-You'll find it's much easier if you are also using maven3 as your runner, so we'll mostly assume that, too.
+You'll find it's much easier if you are also using Maven 3 as your runner, so we'll mostly assume that, too.
 
 ## Overview
 
-Tests follow the normal JUnit pattern: a Test Class contains test methods, each test method sets up a condition, makes some server interaction, then makes some assertions about the results of the interaction (examining the returned status, or the returned object(s)).
+Tests follow the normal JUnit pattern: a test class contains test methods, each test method sets up a condition, makes
+some server interaction, then makes some assertions about the results of the interaction (examining the returned status,
+or the returned object(s)).
 
-The CTK starts with normal JUnit, then provides two major GA4GH-specific facilities: datatyped-communications with the target server, and flexible assertions about the returned objects. 
+The CTK starts with normal JUnit, then provides two major GA4GH-specific facilities: datatyped-communications with the
+target server, and flexible assertions about the returned objects.
 
 ### JUnit Test Mechanics
 
@@ -21,121 +25,129 @@ In this section we'll go over the JUnit-level issues.
 
 Let's explore some scenarios:
 
-1. adding a simple test (method) to an existing TestClass
+1. adding a simple test (method) to an existing test class
 1. adding a data-driven/parameterized test method
-1. adding a new TestClass to an existing package or protocol
+1. adding a new test class to an existing package or protocol
 
 #### Adding a test method to existing test class
 - name can be anything, so describe the end goal in domain terms e.g., "allSequencesShouldMatchPattern"
 - annotate the method with @Test
 - simplest method signature is `@Test public void <testname>() throws Exception {...}`
 - use javadoc to explain the test
-- use `log` to report behavior of your test class, use `testlog` to report test results if you want (other than simple pass/fail, those are automatic based on whether you fail any assertions)
+- use `log` to report behavior of your test class, use `testlog` to report test results if you want (other than simple
+pass/fail, those are automatic based on whether you fail any assertions)
 - normal JUnit structure: try to structure tests as setup, action, assertion
-- Usually you'll want to have just one assertion, and most commonly it will start with `org.assertj.core.api.Assertions.assertThat(`*actual result*`).`...; but in some cases you can fruitfully use "`SoftAssertion`" facility to report multiple failures in one test. 
+- Usually you'll want to have just one assertion, and most commonly it will start with
+`org.assertj.core.api.Assertions.assertThat(`*actual result*`).`...; but in some cases you can fruitfully use
+"`SoftAssertion`" facility to report multiple failures in one test.
 
 #### Adding a data-driven/parameterized test method
 - your test class needs to be run with `@RunWith(JUnitParamsRunner.class)`
-- annotate test method with one of the forms of `@Parameter`, and add the parameters to the test method signature (for lots of options here, see the doc at https://github.com/Pragmatists/JUnitParams/wiki/Quickstart)
-- consider using `@TestCaseName(...)` to make better test case names (see doc in source at https://github.com/Pragmatists/JUnitParams/blob/master/src/main/java/junitparams/naming/TestCaseName.java)
+- annotate test method with one of the forms of `@Parameter`, and add the parameters to the test method signature (for
+lots of options here, see the doc at https://github.com/Pragmatists/JUnitParams/wiki/Quickstart)
+- consider using `@TestCaseName(...)` to make better test case names (see doc in source at
+https://github.com/Pragmatists/JUnitParams/blob/master/src/main/java/junitparams/naming/TestCaseName.java)
 
-#### Adding a new TestClass to an existing package or protocol
-- Add the class in the **`src/test/java`** tree of the `cts-java` module
-- I repeat, add to the **TEST** tree.
-- Put test in some subpackage of `org.ga4gh.cts`.
-- Ensure the class name either starts or ends with "IT" (e.g., `org.ga4gh.cts.api.reads.MyReadsAreBetterIT.java`
-- Add "implements CtkLogs" (or else, directly establish the logger static vars, see the `org.ga4gh.ctk.CtkLogs` javadoc)
-- Add the @BeforeClass to set up a protocol client, and to re-initialize the URLMAPPER
-- `import static org.assertj.core.api.Assertions.*;`
+#### Adding a new test class to an existing package or protocol
+- Add the class in some subpackage of `org.ga4gh.cts` in the **`src/test/java`** tree of the `cts-java` module
+- I repeat, add to the **test** tree, not the **main** tree.
+- Ensure the class name either starts or ends with "IT" ("Integration Test"),
+e.g. `org.ga4gh.cts.api.reads.MyReadsAreBetterIT.java`.
+- Add "implements CtkLogs" (or directly establish the logger static vars, see the JavaDoc for `org.ga4gh.ctk.CtkLogs`)
+- Add the `@BeforeClass` method to set up a protocol client, and to re-initialize the URLMAPPER
+- You'll probably want to add `import static org.assertj.core.api.Assertions.*;` to your class.
 
 ##### Choosing a TestRunner
-Your test class is going to be run by a JUnit Runner; all the methods in the class will be run by the same Runner. Different runners provide different capabilities, so you need to know about your possibilities, and you might need to split your tests into different test classes to run under different Runners.
+Your test class is going to be run by a JUnit Runner; all the methods in the class will be run by the same Runner.
+Different runners provide different capabilities, so you need to know the possibilities, and you might need to
+split your tests into different test classes to run under different Runners.
 
 You select the Runner with a `@RunWith` annotation at the class level. The CTK-available Runners are:
 - (default, no @RunWith) BlockJUnit4ClassRunner
-- `@RunWith(WildcardPatternSuite.class)` allows selecting tests, is used to build a TestSuite (see, e.g., `org.ga4gh.cts.api.reads.ReadsTestSuite`)
-- `@RunWith(JUnitParams.class)` has flexible ways to pass parameters to you test methods; see the [JUnitParams github site](https://github.com/Pragmatists/JUnitParams)
-- `@RunWith(Theories.class)` - not used yet, but expected soon, see [Theories javadoc](http://junit.org/apidocs/org/junit/experimental/theories/Theories.html) or the [JavaCodeGeeks writeup](http://www.javacodegeeks.com/2013/12/introduction-to-junit-theories.html)
+- `@RunWith(WildcardPatternSuite.class)` allows selecting tests, is used to build a TestSuite (see, e.g.,
+`org.ga4gh.cts.api.reads.ReadsTestSuite`)
+- `@RunWith(JUnitParams.class)` has flexible ways to pass parameters to you test methods; see the [JUnitParams github
+site](https://github.com/Pragmatists/JUnitParams)
 
 ### Datatyped Communications
 
-Creating a new API "Foo" has two major steps - creating the FooProtocolClient which communicates with the new endpoints, and creating the classes and/or marker interfaces that we can use to control which tests get executed (the test-control infrastructure). Then we just write normal JUnit tests.
+Creating a new API "Foo" has two major steps - creating the protocol client to communicate with the new endpoints,
+and creating the classes and/or marker interfaces that we can use to control which tests get executed (the test-control
+infrastructure). Then we just write normal JUnit tests.
 
-#### Creating a FooProtocolClient
->**Design note**: doing this is going to be pretty much a cut/paste, but making a code-gen facility doesn't seem worth the overhead for the few clients we'll need... and concrete inheritance or even genericizing seems a bit premature for the payoff, since we won't make many ProtocolClients and we don't know that the evolving GA4GH APIs will follow the pattern we have used to date. So we'll leave these as disconnected classes for now.
+#### Creating a Protocol Client
 
-The FooProtocolClient goes in the `transport` package:
-
-- add the Foo endpoints (often specified in comments in the IDL) to `transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java`
-- add the Foo endpoints to `transport/src/main/resources/defaulttransport.properties`
-- Create a new `org.ga4gh.ctk.transport.FooProtocolClient` in `transport` module, in `org.ga4gh.ctk.transport.protocols` (don't forget to add description to `package-info.java`)
-- FooProtocolClient should `implements org.ga4gh.GAFooMethods` - a protocol is specified by the IDL!
-(Hint - your IDE will probably offer implement the defined methods to get messages stubbed; after you fill these in, don't forget to create an overload method for each that takes the additional WireAssert parameter, as you see in `ReadsProtocolClient` or `VariantsProtocolClient`)
-- for each method in the FooProtocolClient, repeat a pattern like this from the ReadsProtocolClient:
-
-```java
-    @Override
-    public GASearchReadsResponse searchReads(GASearchReadsRequest request) throws AvroRemoteException, GAException {
-        String path = URLMAPPING.getSearchReads(); // get endpoint path
-        GASearchReadsResponse response = new GASearchReadsResponse(); // create the expected Response 
-        AvroJson aj = // create teh communications interaction object
-                new AvroJson<>(request, response, URLMAPPING.getUrlRoot(), path, wireTracker);
-        response = (GASearchReadsResponse) aj.doPostResp(); // doGetResp() or doPostResp()
-        return response;
-    }
-
-```
+See the document (Test Architecture and Conventions)[TestArchAndConventions.md] for details.
 
 #### Creating Infrastructure for Foo
 
-Tests (and infrastructure) go in the **`test/`** subtree of the `cts-java` module. Here is the suggested (but not mandatory) pattern:
+Tests (and infrastructure) go in the **`test/`** subtree of the `cts-java` module. Here is the suggested (but not
+mandatory) pattern:
 
-- Add a java package `org.ga4gh.ctk.systests.api.Foo` in the **test** tree of the `cts-java` module
-- Add a test class `FooMethodsEndpointAliveIT.java` in that package (see examples) to verify the Foo endpoint is reachable and responsive
-- optionally create marker interface for test control, in the **test** tree of `ctk-cli` at `org.ga4gh.ctk.control.API.FooTests.java`
-- optionally create `org.ga4gh.ctk.systests.FooTestSuite.java`
+- Add a java package `org.ga4gh.ctk.systests.api.Foo` in the **test** tree of the `cts-java` module.
+- Add a test class `FooMethodsEndpointAliveIT.java` in that package (see examples) to verify the Foo endpoint is
+reachable and responsive.
+- Optionally create marker interface for test control, in the **test** tree of `ctk-cli` at
+`org.ga4gh.ctk.control.API.FooTests.java`.
+- Optionally create `org.ga4gh.ctk.systests.FooTestSuite.java`.
 
 ### Assertions
 
-1. using core AssertJ (the fluent assertions library)
-1. adding (and using) a domain object custom assertion
-1. adding (and using) a new domain Predicate or Condition
+1. Using core AssertJ (the fluent assertions library)
+1. Adding and using domain object custom assertions
 
 #### Using core AssertJ (the fluent assertions library)
-Motivational - see the [AssertJ website](http://joel-costigliola.github.io/assertj/), we're using Version 3.1.0 (or later) of that (and generated custom assertions for the GA4GH IDL-defined classes).
+Though you can use plain old JUnit assertions, we include the [`AssertJ`](http://joel-costigliola.github.io/assertj/ library
+to help you write more readable, and perhaps more concise, tests.  As part of the build process, we also generate custom
+assertion libraries for the GA4GH objects.  See the
+[next section](#adding-and-using-domain-object-custom-assertions).
 
-The core begins with the org.assertj.core.api.Assertions.assertThat() method (usually you'll want to static import that, so you can just write `assertThat(...)`
+Begin with the `org.assertj.core.api.Assertions.assertThat()` method (usually you'll want to `static import` that,
+so you can just write `assertThat(...)` in your code.
 
-The argument you pass to `assertThat` is the thing you want to make assertions about, and the machinery will look at the Java type of that argument to make sure you're calling applicable assertions on it.
+The argument you pass to `assertThat` is the object you want to make assertions about.  The assertions machinery (and your
+IDE) will look at the Java type of that argument to make sure you're making assertions that are applicable to it.
 
-**NEED EXAMPLES HERE **
+#### Adding and using domain object custom assertions
+One of the key ways the CTK will be useful is as we build up libraries of domain-specific assertions and encode them in
+reusable Java 8 `Predicate`s or `Condition`s to power the assertions. Keep this in mind as you write tests: can you extract
+and contribute a core `Predicate` or `Condition`?
 
-#### Adding (and using) a domain object custom assertion
-One of the key ways the CTK will be useful is as we build up libraries of domain-specific assertions and encode them in reusable Java 8 Predicates or Conditions to power the assertions. Keep this in mind as you write tests: can you extract and contribute a core Predicate or Condition?
+There are more details in [`Predicate`s and `Condition`s for GA4GH](PredicatesAndConditions.md).
 
-There will be more details in [Predicates and Conditions for GA4GH](PredicatesAndConditions.md)
+Although the custom `Predicate`s and `Condition`s will add great reusability and conciseness over time, even as we start
+we have a lot of tools in the core generated assertions. These start from each domain object (the `org.ga4gh.GA*`
+classes) and a couple of the CTK support classes (`org.ga4gh.ctk.transport.WireTracker` and `RespCode`). The generated
+assertions are named after the object they assert on, with an `Assert` suffix - so, for example, `WireTrackerAssert`
+provides custom assertions about a `WireTracker`.
 
-Although the custom Predicates and Conditions will add great reusability and conciseness over time, even as we start we have a lot of tools in the core generated assertions. These start from each domain object (the `org.ga4gh.GA*` classes) and a couple of the CTK support classes (`org.ga4gh.ctk.transport.WireTracker` and `RespCode`). The generated assertions are named after the object they assert on, with an Assert suffix - so, for example, WireTrackerAssert provides custom assertions about a WireTracker.
+The Asserts are generated by a Maven plugin, but once they were generated the Maven plugin was disabled and the Asserts
+were checked into the CTK source; so, we can edit these to add more customized assertions. If you need to re-generate
+the Assertions, you can re-enable the Maven plugin (`assertj-assertions-generator-maven-plugin`) in `ctk-transport`
+and/or `ctk-domain`.
 
-The Asserts are generated by a Maven plugin, but once they were generated the Maven plugin was disabled and the Asserts were checked into the CTK source; so, we can edit these to add more customized assertions. If you need to re-generate the Assertions, you can re-enable the Maven plugin (`assertj-assertions-generator-maven-plugin`) in `ctk-transport` and/or `ctk-domain`.
-
-The generated Asserts let us make test assertions based on the fields of the objects - so, for a WireTrackerAssert object we might have a test case that says:
+The generated Assertions let us make test assertions based on the fields of the objects.  Using the basic `AssertJ` assertions,
+we can test the response code in a `WireTracker` object like this:
 
 ```java
 
- WireTrackerAssert.assertThat(mywt)
-                .hasResponseStatus(RespCode.NOT_FOUND);
+    WireTracker wt = ...;
+    assertThat(wt.getResponseStatus()).isEqualTo(RespCode.NOT_FOUND);
+    ...
 
 ```
 
-The custom assertion here is `hasResponseStatus` based on the WireTracker's responseStatus field. Similarly there are custom assertions for the fields of the GA* classes.
+Using the generated `WireTrackerAssert` assertion object, we can state this more clearly using `hasResponseStatus`:
 
-These generated assertions only add some naming and datatyping fluency, not any logic. To add a logical custom assertion, you edit a new method on the Assert.
+```java
 
- WORKING HERE
+    WireTracker wt = ...;
+    WireTrackerAssert.assertThat(wt).hasResponseStatus(RespCode.NOT_FOUND);
 
-#### Adding (and using) a new domain Predicate or Condition
+```
 
-WORKING HERE
+We also generate custom assertion classes for the fields of the GA4GH classes.
 
+These generated assertions only add some naming and datatyping fluency, not any logic. To add a logical custom
+assertion, you edit a new method on the Assert.
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
 
 
     <properties>
-        <ga4gh.schema.local.version>0.6.0-PRE</ga4gh.schema.local.version>
+        <ga4gh.schema.local.version>0.5.1-SNAPSHOT</ga4gh.schema.local.version>
         <ctk.tgt.urlRoot>http://localhost:8000/v0.5.1</ctk.tgt.urlRoot>
 
         <java.version>1.8</java.version>


### PR DESCRIPTION
- Fix to Maven build problems (I hope).  If you tried to build before, you should clean out the JARs you built before from your local Maven cache:

```
    $ rm -r ~/.m2/repository/org/ga4gh
```

- You can now supply a dataset ID to override the default standard compliance test data:

Supply `-Dcfg.tgt.dataset_id="name"` to the `java` program:

```
    $ java -Dcfg.tgt.dataset_id="my compliance data"` org.ga4gh....
```
Or supply `--cfg.tgt.dataset_id="name"` to the `ctk` shell script:

```
    $ ctk --cfg.tgt.dataset_id="my compliance data" ...
```

Plus:
Lots of doc fixes.
Some new tests.
One bug fix (sorry, no issue ID).
