### PR TITLE
Remove version numbers from example and default URLs

### DIFF
--- a/ctk-cli/src/main/resources/application.properties
+++ b/ctk-cli/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 ### Target server configuration setup
-ctk.tgt.urlRoot=http://localhost:8000/v0.5.1
+ctk.tgt.urlRoot=http://localhost:8000
 
 ### CTK control of what tests get executed
 # name of java package to scan for classes matching the patterns

--- a/ctk-cli/src/main/resources/ctk
+++ b/ctk-cli/src/main/resources/ctk
@@ -5,7 +5,7 @@
 # This script launches the CTK, passing in properties you specify on the
 # command line using "--<property name>=<property value>". Example:
 #
-# ./ctk --ctk.tgt.urlRoot=http://localhost:8000/v0.5.1 --cts.matchstr=**/*IT.class
+# ./ctk --ctk.tgt.urlRoot=http://localhost:8000 --cts.matchstr=**/*IT.class
 #
 # You can also control the CTK using the application.properties
 # and log4j2.xml files, or by simply setting the controlling properties in

--- a/ctk-server/pom.xml
+++ b/ctk-server/pom.xml
@@ -23,7 +23,7 @@
         <java.version>1.8</java.version>
 
         <ga4gh.schema.local.version>0.5.1-SNAPSHOT</ga4gh.schema.local.version>
-        <ctk.tgt.urlRoot>http://localhost:8000/v0.5.1</ctk.tgt.urlRoot>
+        <ctk.tgt.urlRoot>http://localhost:8000</ctk.tgt.urlRoot>
 
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ctk-server/src/main/resources/application.properties
+++ b/ctk-server/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 ### Target server configuration setup
-ctk.tgt.urlRoot=http://192.168.2.214:8000/v0.5.1
+ctk.tgt.urlRoot=http://192.168.2.214:8000
 
 ### CTK control of what tests get executed
 # name of java package to scan for classes matching the patterns

--- a/ctk-server/src/main/resources/ctk
+++ b/ctk-server/src/main/resources/ctk
@@ -5,7 +5,7 @@
 # This script launches the CTK, passing in properties you specify on the
 # command line using "--<property name>=<property value>". Example:
 #
-# ./ctk --ctk.tgt.urlRoot=http://localhost:8000/v0.5.1 --cts.matchstr=**/*IT.class
+# ./ctk --ctk.tgt.urlRoot=http://localhost:8000 --cts.matchstr=**/*IT.class
 #
 # You can also control the CTK using the application.properties
 # and log4j2.xml files, or by simply setting the controlling properties in

--- a/ctk-testrunner/src/main/resources/application.properties
+++ b/ctk-testrunner/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 ### Target server configuration setup
-ctk.tgt.urlRoot=http://localhost:8000/v0.5.1
+ctk.tgt.urlRoot=http://localhost:8000
 
 ### CTK control of what tests get executed
 # name of java package to scan for classes matching the patterns

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java
@@ -8,13 +8,13 @@ import java.util.Map;
 public interface URLMAPPING {
 
     /**
-     * </p>The urlRoot is a string such as http://localhost:8000/v0.5.1<p>
+     * </p>The urlRoot is a string such as http://localhost:8000<p>
      * @return the URL to be used to reach the target server
      */
     String getUrlRoot();
 
     /**
-     * </p>The urlRoot is a string such as http://localhost:8000/v0.5.1<p>
+     * </p>The urlRoot is a string such as http://localhost:8000<p>
      * @param urlRoot URL to be used to reach the target server
      */
     void setUrlRoot(String urlRoot);

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
@@ -62,7 +62,7 @@ public class AvroJson<Q extends SpecificRecordBase, P extends SpecificRecordBase
     final DatumWriter<Q> dw;
     final Q theAvroReq;
     /**
-     * url root to system-under-test; e.g., "http://localhost:8000/v0.5.1/"
+     * url root to system-under-test; e.g., "http://localhost:8000"
      */
     String urlRoot;
     /**

--- a/ctk-transport/src/main/resources/defaulttransport.properties
+++ b/ctk-transport/src/main/resources/defaulttransport.properties
@@ -1,6 +1,6 @@
 ### Target server configuration setup
 #
-ctk.tgt.urlRoot=http://localhost:8000/v0.5.1/
+ctk.tgt.urlRoot=http://localhost:8000
 
 # map message to resource path, per the IDL comments
 

--- a/ctk-transport/src/test/java/org/ga4gh/ctk/transport/URLMAPPINGTest.java
+++ b/ctk-transport/src/test/java/org/ga4gh/ctk/transport/URLMAPPINGTest.java
@@ -1,8 +1,10 @@
 package org.ga4gh.ctk.transport;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * URLMAPPING Tester.
@@ -56,7 +58,7 @@ public class URLMAPPINGTest {
     //@Test
     public void testGetUrlRoot() throws Exception {
         String url = urlmapping.getUrlRoot();
-        assertThat(url).isEqualTo("http://localhost:8000/v0.5.1/");
+        assertThat(url).isEqualTo("http://localhost:8000");
     }
 
     /**

--- a/cts-java/src/main/resources/defaulttransport.properties
+++ b/cts-java/src/main/resources/defaulttransport.properties
@@ -1,6 +1,6 @@
 ### Target server configuration setup
 #
-ctk.tgt.urlRoot=http://localhost:8000/v0.5.1/
+ctk.tgt.urlRoot=http://localhost:8000
 
 # map message to resource path, per the IDL comments
 

--- a/docs/ConfigTheCTK.md
+++ b/docs/ConfigTheCTK.md
@@ -1,8 +1,10 @@
 # Configuring the CTK
 
-The CTK is controlled through properties to set up the target server information, and to control the test finding/selection mechanism. Logging is controlled by a standard `log4j2.xml` file.
+The CTK is controlled through properties to set up the target server information, and to control the test
+finding/selection mechanism. Logging is controlled by a standard `log4j2.xml` file.  You generally have no
+need to edit this file.
 
-You configure the CTK via the properties used by the:
+You can configure the CTK via the properties used by the:
 
 - `transport` module to control target server URLS (see `/transport/src/main/resources/defaulttransport.properties/`
 - `ctk-cli` module to control:
@@ -47,7 +49,7 @@ Note that many tests reinitialize the URLMAPPER in a @BeforeClass, so you may se
 Properties can be set on the command line, from a properties file (in various locations), or from environment variables. The mechanism is provided by Spring, so all the alternatives described in Spring documentation on [Externalized Configuration](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html) are available. The important mechanisms for the CTS, in order of descending priority, are:
 
 1. Command line arguments when running the `ctk-cli` jar from the command line: anything starting with "--" becomes a system property, so `--ctk.testpackage=...` will set the property "`ctk.testpackage`" (this works with the bash script, as
-	- `./ctk --ctk.tgt.urlRoot=http://localhost:8000/v0.5.1"` or,
+	- `./ctk --ctk.tgt.urlRoot=http://localhost:8000` or,
 	- from a Java launch line as `java -jar ... --ctk.tgt.urlRoot=...`
 1. Operating System/shell environment variables
 1. Application properties files outside of the packaged jar (`application.properties` and YAML variants); the highest priority would be a `/config` subdir of the current directory, and next would be in the current directory when the test is launched. (The Spring documentation describes other locations, and even ways to change the properties files names if you want.) 
@@ -63,7 +65,7 @@ xxx
 
 To set properties as a command line variable (the highest priority) for a Maven invocation from a command line, just use the normal Maven invocation model of `-Dprop_name=prop_value` before the goal name, like this:
 
-    mvn -Dctk.tgt.urlRoot=http://localhost:8000/v0.5.1/ install 
+    mvn -Dctk.tgt.urlRoot=http://localhost:8000 install
 
 ### Configuring a Command Line invocation
 From the directory where the executable jar is, you can edit `application.properties`. The zip distribution has this file pre-extracted, but if you don't already have it, just extract it from the executable jar like this

--- a/docs/README-IntroAtCommandLine.txt
+++ b/docs/README-IntroAtCommandLine.txt
@@ -29,7 +29,7 @@ in txt and XML in `target`, and HTML versions in `target/report/html/`
 
 so, for example,
 
-  java -jar ctk-cli-0.5.1-SNAPSHOT.jar -Dctk.tgt.urlRoot=http://myserver:8000/v0.5.1
+  java -jar ctk-cli-0.5.1-SNAPSHOT.jar -Dctk.tgt.urlRoot=http://myserver:8000
 
 Tip - if you're regularly testing against the same server, you can set an environment
 variable "ctk_tgt_urlRoot" (or "ctk.tgt.urlRoot" if your environment prefers that)
@@ -37,7 +37,7 @@ to avoid having to re-enter that URL all the time on the command line.
 How you set environment variables varies with your shell, but a common
 example would be to add to your ~/.bashrc a line like"
 
-  export ctk_tgt_urlRoot='http://myserver:8000/v0.5.1'
+  export ctk_tgt_urlRoot='http://myserver:8000'
 
 We'll stop adding that ctk.tgt.urlRoot property to the example command lines now.
 
@@ -60,7 +60,7 @@ and see that you can run with just:
 This will use defaults and environment variables and property files. If you want to override
 some properties, add the property and new value to the command line:
 
-    ./ctk --ctk.tgt.urRoot=http://myserver:8000/v0.5.1/
+    ./ctk --ctk.tgt.urRoot=http://myserver:8000
 
 Just as when running using the 'java' command, there will be some console output, and you can
 check in `target/report` for details; if you have a browser, check out
@@ -141,7 +141,7 @@ You can see and set these in the `application.properties` file. Properties can a
 NOTE: in a 'bash' environment, you need to replace the '.' in variable names with underscore '_' when you set the
 variables in the environment; so, do something like:
 
-export ctk_tgt_urlRoot='http://localhost:8000/v0.5.1/'
+export ctk_tgt_urlRoot='http://localhost:8000'
 
 Generally, properties can be:
 - set in the environment, or
@@ -160,7 +160,7 @@ matched against class names:
 
 
     ~/temp>java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.matchstr=**/*ReadMethodsEndpointAliveIT.class /
-           --ctk.tgt.urlRoot=http://192.168.2.115:8000/v0.5.1/
+           --ctk.tgt.urlRoot=http://192.168.2.115:8000
     [TESTLOG] 4 failed, 6 passed, 0 skipped, 1068 ms
     [TESTLOG] FAIL: [0] TWO_GOOD, NOT_IMPLEMENTED (multipleReadGroupsNotSupported)(org.ga4gh.cts.api.reads.ReadMethodsEndpointAliveIT):
     ...

--- a/docs/RunningTests_CLI.md
+++ b/docs/RunningTests_CLI.md
@@ -18,11 +18,11 @@ When the tests are done, the reports will be in the `target/` directory. There a
 
 so, for example,
 
-    java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.tgt.urlRoot=http://myserver:8000/v0.5.1
+    java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.tgt.urlRoot=http://myserver:8000
 
 Tip - if you're regularly testing against the same server, you can set an operating system environment variable "`ctk_tgt_urlRoot`" (or "`ctk.tgt.urlRoot`" if your environment prefers that) to avoid having to re-enter that URL all the time on the command line. How you set environment variables varies with your shell, but a common example would be to add to your ~/.bashrc a line like"
 
-    export ctk_tgt_urlRoot='http://myserver:8000/v0.5.1/'
+    export ctk_tgt_urlRoot='http://myserver:8000'
 
 We'll stop adding that `ctk.tgt.urlRoot` property to the example command lines now.
 
@@ -52,7 +52,7 @@ and see that you can run with just:
 
 This will use defaults and environment variables and property files. If you want to override some properties, add the property and new value to the command line:
 
-    ./ctk --ctk.tgt.urRoot=http://myserver:8000/v0.5.1/
+    ./ctk --ctk.tgt.urRoot=http://myserver:8000
 
 Just as when running using the 'java' command, there will be some console output, and you can check in `target/report` for details; if you have a browser, check out `target/report/html/index.html`
 
@@ -111,7 +111,7 @@ You can see and set these in the `application.properties` file. Properties can a
 
 NOTE: in a 'bash' environment, you need to replace the '.' in variable names with underscore '_' when you set the variables in the environment; so, do something like:
 
-`export ctk_tgt_urlRoot='http://localhost:8000/v0.5.1/'`
+`export ctk_tgt_urlRoot='http://localhost:8000'`
 
 at a command line or in your .bashrc or as appropriate for your system.
 
@@ -129,7 +129,7 @@ If you want to alter which tests get run, you can do that on the command line
 
 ```
 
-    ~/temp>java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.matchstr=.*ReadMethodsEndpointAliveIT.* --ctk.tgt.urlRoot=http://192.168.2.115:8000/v0.5.1/
+    ~/temp>java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.matchstr=.*ReadMethodsEndpointAliveIT.* --ctk.tgt.urlRoot=http://192.168.2.115:8000/
     [TESTLOG] 4 failed, 6 passed, 0 skipped, 1068 ms
     [TESTLOG] FAIL: [0] TWO_GOOD, NOT_IMPLEMENTED (multipleReadGroupsNotSupported)(org.ga4gh.cts.api.reads.ReadMethodsEndpointAliveIT):
     ...

--- a/docs/RunningTests_maven.md
+++ b/docs/RunningTests_maven.md
@@ -25,9 +25,7 @@ Both plugins can run the same tests, so we use our CTK naming convention to spli
 
 surefire plugin as the test runner, so the main CTK Application isn't involved. Still, stdout and the default TESTLOG should be available in your terminal (this may vary if you elect to run Maven under an IDE which itself manages I/O routing).
 
-
-
-**Most important property** to check is: `ctk.tgt.urlRoot=http://localhost:8000/v0.5.1`
+**The most important property** to check is: `ctk.tgt.urlRoot=http://localhost:8000`
 
 To alter logging behavior: modify `log4j2.xml` in source/test for a build/run launch in your IDE or in Maven, or modify `lib/log4j2.xml` for a command-line launch.
 

--- a/docs/WritingATest.md
+++ b/docs/WritingATest.md
@@ -4,7 +4,7 @@ This covers the mechanics of adding tests to the `cts-java` module.
 
 ## Prerequisites
 - A reachable GA4GH Server; the CTK framework assumes this is available at the URL provided by the `ctk.tgt.urlRoot`
-property (e.g., `http://192.168.2.115:8000/v0.5.1/`)
+property (e.g., `http://192.168.2.115:8000`)
 - The CTK source installed (see [Installing The CTK](InstallingTheCTK.md))
 - You're familiar with the [CTK Test Architecture and Conventions](TestArchAndConventions.md)
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <ga4gh.schema.local.version>0.5.1-SNAPSHOT</ga4gh.schema.local.version>
-        <ctk.tgt.urlRoot>http://localhost:8000/v0.5.1</ctk.tgt.urlRoot>
+        <ctk.tgt.urlRoot>http://localhost:8000</ctk.tgt.urlRoot>
 
         <java.version>1.8</java.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
The ref server just dropped version numbers from its URLs, and it see…ms that that's not the custom with other GA4GH servers.  I edited docs and config files to drop the `/v0.5.1` suffixes from default and example URLs.