### PR TITLE
Fixed problems merging server base URL with endpoints when the base contains a query string

### DIFF
--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/FragmentEncoder.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/FragmentEncoder.java
@@ -1,4 +1,4 @@
-package com.shopobot.util;
+package org.ga4gh.ctk.transport;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
@@ -9,7 +9,9 @@ import java.nio.charset.UnsupportedCharsetException;
 
 /**
  * This class is used to encode a string using the format required by <a
- * href="http://tools.ietf.org/html/rfc3986">RFC 3986</a>
+ * href="http://tools.ietf.org/html/rfc3986">RFC 3986</a>.
+ *
+ * @author <a href="https://github.com/juliuss">julius schorzman</a>
  */
 public class FragmentEncoder {
 

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/TransportUtils.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/TransportUtils.java
@@ -1,0 +1,41 @@
+package org.ga4gh.ctk.transport;
+
+/**
+ * Transport-related utilities.
+ *
+ * @author Herb Jellinek
+ */
+public class TransportUtils {
+
+    /**
+     * You can't instantiate one of these.
+     */
+    private TransportUtils() {
+    }
+
+    /**
+     * Create a new URL (as a string) based on a server root (which may include path components
+     * and query parameters) and a path that's relative to the server root.
+     * <p>For instance, if we have <tt>baseUrl</tt> = <tt>https://locahost:8000/v1.0?param1=foo&param2=bar</tt>
+     * and <tt>path</tt> = "datasets/search", the result should be
+     * <tt>https://locahost:8000/v1.0/datasets/search?param1=foo&param2=bar</tt>.
+     * </p>
+     * @param baseUrl a server root URL
+     * @param path relative path
+     * @return the result of merging the root and path, accounting for path components and query parameters
+     * in baseUrl
+     */
+    public static String makeUrl(String baseUrl, String path) {
+        final URL baseAsUrl = new URL(baseUrl);
+        String baseUrlPathPortion = baseAsUrl.getPath();
+
+        if (!baseUrlPathPortion.endsWith("/")) {
+            baseUrlPathPortion += "/";
+        }
+
+        final URL constructed = new URL(baseAsUrl.toJavaURL());
+        constructed.setPath(baseUrlPathPortion+path);
+        return constructed.toString();
+    }
+
+}

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URL.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URL.java
@@ -1,4 +1,4 @@
-package com.shopobot.util;
+package org.ga4gh.ctk.transport;
 
 import java.io.UnsupportedEncodingException;
 import java.net.*;

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
@@ -14,12 +14,12 @@ import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.message.BasicStatusLine;
-import org.ga4gh.ctk.transport.URL;
 import org.ga4gh.ctk.transport.WireTracker;
 
 import java.util.Map;
 
 import static org.ga4gh.ctk.transport.RespCode.fromInt;
+import static org.ga4gh.ctk.transport.TransportUtils.makeUrl;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -193,30 +193,6 @@ public class AvroJson<Q extends SpecificRecordBase, P extends SpecificRecordBase
         log.info(toString());
     }
 
-    /**
-     * Create a new URL (as a string) based on a server root (which may include path components
-     * and query parameters) and a path that's relative to the server root.
-     * <p>For instance, if we have <tt>baseUrl</tt> = <tt>https://locahost:8000/v1.0?param1=foo&param2=bar</tt>
-     * and <tt>path</tt> = "datasets/search", the result should be
-     * <tt>https://locahost:8000/v1.0/datasets/search?param1=foo&param2=bar</tt>.
-     * </p>
-     * @param baseUrl a server root URL
-     * @param path relative path
-     * @return the result of merging the root and path, accounting for path components and query parameters
-     * in baseUrl
-     */
-    private static String makeUrl(String baseUrl, String path) {
-        final URL baseAsUrl = new URL(baseUrl);
-        String baseUrlPathPortion = baseAsUrl.getPath();
-
-        if (!baseUrlPathPortion.endsWith("/")) {
-            baseUrlPathPortion += "/";
-        }
-
-        final URL constructed = new URL(baseAsUrl.toJavaURL());
-        constructed.setPath(baseUrlPathPortion+path);
-        return constructed.toString();
-    }
 
     /**
      * <p>Access the message-traffic recording Table.</p>

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/avrojson/AvroJson.java
@@ -7,7 +7,6 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
-import com.shopobot.util.URL;
 import org.apache.avro.Schema;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
@@ -15,6 +14,7 @@ import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.message.BasicStatusLine;
+import org.ga4gh.ctk.transport.URL;
 import org.ga4gh.ctk.transport.WireTracker;
 
 import java.util.Map;

--- a/ctk-transport/src/test/java/org/ga4gh/ctk/transport/URLTest.java
+++ b/ctk-transport/src/test/java/org/ga4gh/ctk/transport/URLTest.java
@@ -1,10 +1,15 @@
-package com.shopobot.util;
+package org.ga4gh.ctk.transport;
 
 import junit.framework.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Tests for class {@link URL}.
+ *
+ * @author <a href="https://github.com/juliuss">julius schorzman</a>
+ */
 public class URLTest {
 
   @Test

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -6,6 +6,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.avro.AvroRemoteException;
 import org.ga4gh.ctk.CtkLogs;
+import org.ga4gh.ctk.transport.TransportUtils;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
@@ -38,7 +39,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
     private static Client client = new Client(urls);
 
     private static String makeUrl(String partialUrl) {
-        return urls.getUrlRoot() + "/" + partialUrl;
+        return TransportUtils.makeUrl(urls.getUrlRoot(), partialUrl);
     }
 
     /**
@@ -114,7 +115,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
      * Test search routing and the handling of bad data.
      *
      * @param fullUrl the URL to test (supplied by {@link #allSearchUrls()}
-     * @throws UnirestException is there's a communication problem
+     * @throws UnirestException if there's a communication problem
      */
     @Test
     @Parameters(method = "allSearchUrls")


### PR DESCRIPTION
Fixed a packaging problem that prevented this fix from running under the `ctk` shell script.
Also fixed `CallsetsSearchResponseCheckIT` to construct URLs correctly.
