### PR TITLE
Remove unused Jackson dependencies, produce more helpful Enforcer messages

### DIFF
--- a/ctk-cli/pom.xml
+++ b/ctk-cli/pom.xml
@@ -147,9 +147,7 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <!-- provide the google JSON support, easier than
-            Jackson for handling the 'normal' JSON to Avro class
-            deserialization -->
+            <!-- for handling the 'normal' JSON to Avro class deserialization -->
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
@@ -160,18 +158,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.4</version>
-        </dependency>
-
-        <dependency>
-            <!-- transitively brings in jackson-databind, so this
-            triggers log4j2 support for hide_log4j2.json and log4j2.jsm config,
-            as well as providing Jackson-based JSON processing if we want it -->
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
         <!-- need BCEL during site build -->

--- a/ctk-server/pom.xml
+++ b/ctk-server/pom.xml
@@ -39,7 +39,6 @@
         <httpclient.version>4.4.1</httpclient.version>
         <httpmime.version>4.4.1</httpmime.version>
 
-        <jackson2.version>2.5.3</jackson2.version>
         <json-patch.version>1.9</json-patch.version>
         <jsonassert.version>1.2.3</jsonassert.version>
         <junit.version>4.12</junit.version>
@@ -139,9 +138,7 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <!-- provide the google JSON support, easier than
-            Jackson for handling the 'normal' JSON to Avro class
-            deserialization -->
+            <!-- for handling the 'normal' JSON to Avro class deserialization -->
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>

--- a/ctk-testrunner/pom.xml
+++ b/ctk-testrunner/pom.xml
@@ -99,9 +99,7 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <!-- provide the google JSON support, easier than
-            Jackson for handling the 'normal' JSON to Avro class
-            deserialization -->
+            <!-- for handling the 'normal' JSON to Avro class deserialization -->
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>

--- a/ctk-transport/pom.xml
+++ b/ctk-transport/pom.xml
@@ -90,15 +90,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-avro</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>compile</scope>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,6 @@
         <httpclient.version>4.4.1</httpclient.version>
         <httpmime.version>4.4.1</httpmime.version>
 
-        <jackson2.version>2.5.3</jackson2.version>
         <json-patch.version>1.9</json-patch.version>
         <jsonassert.version>1.2.3</jsonassert.version>
         <junit.version>4.12</junit.version>
@@ -181,24 +180,6 @@
                 <version>${jsonassert.version}</version>
                 <scope>compile</scope>
             </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>${jackson2.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-avro</artifactId>
-                <version>${jackson2.version}</version>
-            </dependency>
-
-            <!-- yanl support for log4j2 config .. I wonder if snakeyaml would handle this? -->
-            <!--            <dependency>
-                            <groupId>com.fasterxml.jackson.dataformat</groupId>
-                            <artifactId>jackson-dataformat-yaml</artifactId>
-                            <version>2.5.0</version>
-                        </dependency>-->
 
             <!-- the best general assertions library :) -->
             <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -248,6 +248,34 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.3.3,)</version>
+                                    <message>*** This project requires Maven 3.3.3 or later. ***</message>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[1.8,)</version>
+                                    <message>*** This project requires JDK 1.8/J2SE 8 or later. ***</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -263,11 +263,11 @@
                             <rules>
                                 <requireMavenVersion>
                                     <version>[3.3.3,)</version>
-                                    <message>*** This project requires Maven 3.3.3 or later. ***</message>
+                                    <message>*** This project requires Maven 3.3.3 or later. This is version ${maven.version}. ***</message>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[1.8,)</version>
-                                    <message>*** This project requires JDK 1.8/J2SE 8 or later. ***</message>
+                                    <message>*** This project requires JDK 1.8 (J2SE 8) or later. This is version ${java.version}. }***</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Fix for #32: got rid of unused Jackson dependencies.  Note that Spring uses some other pieces of Jackson.
Also made the two Enforcer messages more helpful.
