### PR TITLE
Compliance redux

### DIFF
--- a/ctk-cli/src/main/resources/application.properties
+++ b/ctk-cli/src/main/resources/application.properties
@@ -18,7 +18,7 @@ ctk.matchstr=${ctk.pattern.testclass}
 # ON makes more output, but it's tolerable and reassuring
 ctk.antlog.consolelogger=OFF
 
-# test counts, fail, etc are accumumulated during each test run, reported at end;
+# test counts, fail, etc are accumulated during each test run, reported at end;
 # shold we clear between runs? Ony should matter when matchstr causes us to
 # do multiple separate runs (not yet supported)
 ctk.antlog.clearstats=OFF
@@ -37,6 +37,9 @@ ctk.testjar=cts-java-0.5.1-SNAPSHOT-tests.jar
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)
 ctk.reporttitle=CTK Test Results of
+
+# This is the dataset ID to use
+ctk.tgt.dataset_id=compliance-dataset-1
 
 # temporarily not used
 #ctk.logging.systest=SYSTEST

--- a/ctk-cli/src/main/resources/ctk
+++ b/ctk-cli/src/main/resources/ctk
@@ -5,7 +5,7 @@
 # This script launches the CTK, passing in properties you specify on the
 # command line using "--<property name>=<property value>". Example:
 #
-# ./ctk --ctk.tgt.urlRoot=http://localhost:8000 --cts.matchstr=**/*IT.class
+# ./ctk --ctk.tgt.urlRoot=http://localhost:8000 --ctk.matchstr=**/*IT.class
 #
 # You can also control the CTK using the application.properties
 # and log4j2.xml files, or by simply setting the controlling properties in

--- a/ctk-server/src/main/java/org/ga4gh/ctk/server/ServerTestController.java
+++ b/ctk-server/src/main/java/org/ga4gh/ctk/server/ServerTestController.java
@@ -1,17 +1,24 @@
 package org.ga4gh.ctk.server;
 
-import org.ga4gh.ctk.*;
-import org.ga4gh.ctk.config.*;
-import org.ga4gh.ctk.transport.*;
-import org.springframework.beans.factory.annotation.*;
-import org.springframework.stereotype.*;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.*;
-import org.springframework.web.servlet.view.*;
+import org.ga4gh.ctk.CtkLogs;
+import org.ga4gh.ctk.ResultsSupport;
+import org.ga4gh.ctk.TestRunner;
+import org.ga4gh.ctk.config.Props;
+import org.ga4gh.ctk.transport.URLMAPPING;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.view.RedirectView;
 
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 /**
+ * Test controller used when running as a server.
+ *
  * Created by Wayne Stidolph on 7/15/2015.
  */
 @Controller
@@ -40,13 +47,12 @@ public class ServerTestController implements CtkLogs {
             // we have a place to put results
             log.info("about to run tests " + urlRoot + " " + mstr + " " + props.ctk_testjar);
             Future<String> futureTestResultIndexPage =
-                    testrunner.doTestRun(urlRoot, mstr, props.ctk_testjar, resultsDir);
+                    testrunner.doTestRun(urlRoot, props.ctk_tgt_dataset_id,
+                                         mstr, props.ctk_testjar, resultsDir);
             String testResultIndexPage = null;
             try { // wait for results
                 testResultIndexPage = futureTestResultIndexPage.get();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            } catch (ExecutionException e) {
+            } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
             }
             log.info("test complete, results to " + testResultIndexPage);

--- a/ctk-server/src/main/resources/application.properties
+++ b/ctk-server/src/main/resources/application.properties
@@ -18,7 +18,7 @@ ctk.matchstr=${ctk.pattern.testclass}
 # ON makes more output, but it's tolerable and reassuring
 ctk.antlog.consolelogger=OFF
 
-# test counts, fail, etc are accumumulated during each test run, reported at end;
+# test counts, fail, etc are accumulated during each test run, reported at end;
 # should we clear between runs?
 ctk.antlog.clearstats=ON
 
@@ -36,6 +36,9 @@ ctk.testjar=cts-java-0.5.1-SNAPSHOT-tests.jar
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)
 ctk.reporttitle=CTK Test Results of
+
+# This is the dataset ID to use
+ctk.tgt.dataset_id=compliance-dataset1
 
 # temporarily not used
 #ctk.logging.systest=SYSTEST

--- a/ctk-server/src/main/resources/ctk
+++ b/ctk-server/src/main/resources/ctk
@@ -5,7 +5,7 @@
 # This script launches the CTK, passing in properties you specify on the
 # command line using "--<property name>=<property value>". Example:
 #
-# ./ctk --ctk.tgt.urlRoot=http://localhost:8000 --cts.matchstr=**/*IT.class
+# ./ctk --ctk.tgt.urlRoot=http://localhost:8000 --ctk.matchstr=**/*IT.class
 #
 # You can also control the CTK using the application.properties
 # and log4j2.xml files, or by simply setting the controlling properties in

--- a/ctk-testrunner/src/main/java/org/ga4gh/ctk/AntExecutor.java
+++ b/ctk-testrunner/src/main/java/org/ga4gh/ctk/AntExecutor.java
@@ -85,20 +85,18 @@ public class AntExecutor {
         this.props = props;
     }
 
-
     /**
      * To execute the default target specified in the Ant antRunTests.xml file
-     *
      */
     public boolean executeAntTask() {
-        return
-                executeAntTask( // use the properties and defaults
-                        props.ctk_testjar,
-                        props.ctk_matchstr,
-                        URLMAPPING.getInstance(),
-                        "testresults/target/",
-                        null
-                    );
+        // use the properties and defaults
+        return executeAntTask(props.ctk_testjar,
+                              props.ctk_matchstr,
+                              URLMAPPING.getInstance(),
+                              props.ctk_tgt_dataset_id,
+                              "testresults/target/",
+                              null
+                             );
     }
 
     /**
@@ -106,7 +104,9 @@ public class AntExecutor {
      *
      * @param testjar tests jar to unpack/run in Ant
      */
-    public boolean executeAntTask(String testjar, String matchstr, URLMAPPING urls, String toDir, BuildListener theBoss) {
+    public boolean executeAntTask(String testjar, String matchstr, URLMAPPING urls,
+                                  String datasetId,
+                                  String toDir, BuildListener theBoss) {
 
         log.trace("passed-in urls has " + urls.getEndpoints());
         log.info("passed-in urls.getUrlRoot " + urls.getUrlRoot());
@@ -125,8 +125,11 @@ public class AntExecutor {
             project.setUserProperty("ctk.testjar", testjar);
             project.setUserProperty("ctk.matchstr", matchstr);
             project.setUserProperty("ctk.reporttitle", expandedReportTitle);
+            project.setUserProperty("ctk.testjar", testjar);
+            project.setUserProperty("ctk.tgt.dataset_id", datasetId);
             project.setUserProperty("ctk.todir", toDir);
             project.addBuildListener(antExecListener);
+
             // if there's an interested listener, hook them up
             if (theBoss != null) {
                 project.addBuildListener(theBoss);
@@ -162,11 +165,13 @@ public class AntExecutor {
             // and thereby use the passed-in values.
             Properties sysprops = new Properties(System.getProperties()); // this one we'll alter
             sysprops.putAll(urls.getEndpoints());
+            sysprops.put("ctk.tgt.dataset_id", datasetId);
             System.setProperties(sysprops);
 
             log.debug("About to run ant, sysprop ctk.tgt.urlRoot " + System.getProperty("ctk.tgt.urlRoot"));
+            log.debug("  ctk.tgt.dataset_id = " + System.getProperty("ctk.tgt.dataset_id"));
             project.executeTarget(targetToExecute);
-            success = true;// well, we got a good launch at least!
+            success = true; // well, we got a good launch at least!
 
             System.setProperties(copySysProp); // restore the system
             log.debug("Done with ant, restored system props, ctk.tgt.urlRoot "
@@ -192,7 +197,7 @@ public class AntExecutor {
     /**
      * Logger to log output generated while executing ant script in console
      *
-     * @return
+     * @return the logger
      */
     private DefaultLogger getConsoleLogger() {
 

--- a/ctk-testrunner/src/main/java/org/ga4gh/ctk/config/Props.java
+++ b/ctk-testrunner/src/main/java/org/ga4gh/ctk/config/Props.java
@@ -1,11 +1,12 @@
 package org.ga4gh.ctk.config;
 
-import lombok.*;
+import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.*;
-import org.springframework.context.annotation.*;
-import org.springframework.context.support.*;
-import org.springframework.stereotype.*;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.stereotype.Component;
 
 /**
  * <p>Access to runtime environment properties.</p>
@@ -98,6 +99,8 @@ public class Props {
     @Value("${ctk.reporttitle}")
     public String ctk_report_title;
 
+    @Value("${ctk.tgt.dataset_id}")
+    public String ctk_tgt_dataset_id;
 
     /* logging control (name of the test/traffic logs) not yet working */
     /*

--- a/ctk-testrunner/src/main/resources/application.properties
+++ b/ctk-testrunner/src/main/resources/application.properties
@@ -18,7 +18,7 @@ ctk.matchstr=${ctk.pattern.testclass}
 # ON makes more output, but it's tolerable and reassuring
 ctk.antlog.consolelogger=OFF
 
-# test counts, fail, etc are accumumulated during each test run, reported at end;
+# test counts, fail, etc are accumulated during each test run, reported at end;
 # shold we clear between runs? Ony should matter when matchstr causes us to
 # do multiple separate runs (not yet supported)
 ctk.antlog.clearstats=OFF
@@ -37,6 +37,9 @@ ctk.testjar=cts-java-0.5.1-SNAPSHOT-tests.jar
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)
 ctk.reporttitle=CTK Test Results of
+
+# This is the dataset ID to use
+ctk.tgt.dataset_id=compliance-dataset1
 
 # temporarily not used
 #ctk.logging.systest=SYSTEST

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPINGImpl.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPINGImpl.java
@@ -91,7 +91,7 @@ public class URLMAPPINGImpl implements URLMAPPING {
      * <li>a properties file of that name on the classpath</li>
      * <li>a properties file of that name from the file system</li>
      * <li>the operating system environment variables ("ctk.tgt.*)</li>
-     * <li>the java system properties (e.g., command line -D...) of "ctk.tgt.*"</li>
+     * <li>the Java system properties (e.g., command line -D...) of "ctk.tgt.*"</li>
      * </ul>
      * If the resName is blank then the file/resource sought is "defaulttransport.properties"
      * If the resName is given then the default properties file is not loaded at all.

--- a/cts-java/src/test/java/org/ga4gh/cts/api/DatasetIdPropertyIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/DatasetIdPropertyIT.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class DatasetIdPropertyIT {
 
-    private static final String PROP_NAME = "cfg.tgt.dataset_id";
+    private static final String PROP_NAME = "ctk.tgt.dataset_id";
 
     /**
      * Check that {@link TestData#getDatasetId()} returns the default dataset ID when
@@ -32,7 +32,7 @@ public class DatasetIdPropertyIT {
             if (originalValue == null) {
                 System.clearProperty(PROP_NAME);
             } else {
-                System.setProperty("cfg.tgt.dataset_id", originalValue);
+                System.setProperty(PROP_NAME, originalValue);
             }
         }
     }
@@ -58,7 +58,7 @@ public class DatasetIdPropertyIT {
             if (originalValue == null) {
                 System.clearProperty(PROP_NAME);
             } else {
-                System.setProperty("cfg.tgt.dataset_id", originalValue);
+                System.setProperty(PROP_NAME, originalValue);
             }
         }
     }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -26,7 +26,7 @@ public class TestData {
      * The name of the Java system property that sets the name of the compliance dataset,
      * if the default (<tt>compliance-dataset1</tt>) is not correct.
      */
-    private static final String DATASET_PROP_NAME = "cfg.tgt.dataset_id";
+    private static final String DATASET_PROP_NAME = "ctk.tgt.dataset_id";
 
     /**
      * The names of the readgroup sets in the standard compliance dataset.
@@ -64,7 +64,7 @@ public class TestData {
     /**
      * Return the ID of the compliance dataset on the server being tested.
      * By default this is the value of {@link #DEFAULT_DATASET_ID}, <tt>compliance-dataset1</tt>, but
-     * it can be overridden by setting the Java property <tt>-Dcfg.tgt.dataset_id</tt>.
+     * it can be overridden by setting the Java property <tt>-Dctk.tgt.dataset_id</tt>.
      */
     public static String getDatasetId() {
         final String propValue = System.getProperty(DATASET_PROP_NAME);

--- a/docs/README-IntroAtCommandLine.txt
+++ b/docs/README-IntroAtCommandLine.txt
@@ -130,7 +130,7 @@ So you end up with:
 
 Advanced tip: if you want to attach a debugger to the command-line CTK, use:
 
-    java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n \
+    java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n \
          -jar ctk-cli-0.5.1-SNAPSHOT.jar
 
 Altering the run

--- a/docs/RunningTests_CLI.md
+++ b/docs/RunningTests_CLI.md
@@ -36,7 +36,7 @@ if you have a browser, check out `target/report/html/index.html`.
 #### Tips
 If you want to attach a debugger to the command-line CTK, use:
 
-    java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n \
+    java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n \
          -jar ctk-cli-0.5.1-SNAPSHOT.jar
 
 For help on using the 'java' command refer to your java vendor's documentation or the help provided with your installation (e.g., `man java` or `java -h`)

--- a/docs/RunningTests_maven.md
+++ b/docs/RunningTests_maven.md
@@ -8,7 +8,7 @@
 Modify the behavior under Maven using:
 - properties set in the `cts-java` Maven `pom.xml`, or
 - on the command line using `mvn -D<property>=<value>`, or
-- `application.properties` to alter which tests are run by default (change `cts.matchstr`),
+- `application.properties` to alter which tests are run by default (change `ctk.matchstr`),
 - `defaulttransport.properties` to alter server endpoints
 
 # Introduction


### PR DESCRIPTION
Fix for #49.
We now allow setting the dataset ID via command line, environment variable, or Java System property.  Note that the new dataset ID property name is `ctk.tgt.dataset_id` (formerly `cfg.tgt.dataset_id`).  Examples:

```bash
$ ./ctk --ctk.tgt.dataset_id=my_dataset_id
```

or

```bash
$ env CTK_TGT_DATASET_ID=my_dataset ./ctk
```

or

```bash
$ java -Dctk.tgt.dataset_id=my_dataset_id -jar ctk-cli-0.5.1-SNAPSHOT.jar
```

etc.