### PR TITLE
GAException support

### DIFF
--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/GAWrapperException.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/GAWrapperException.java
@@ -1,0 +1,69 @@
+package org.ga4gh.ctk.transport;
+
+import org.ga4gh.methods.GAException;
+
+/**
+ * A wrapper for {@link org.ga4gh.methods.GAException}, thrown instead of it.
+ * It includes the HTTP response code the server sent.
+ *
+ * @author Herb Jellinek
+ */
+public class GAWrapperException extends GAException {
+
+    /**
+     * The {@link GAException} we're wrapping.
+     */
+    private final GAException cause;
+
+    /**
+     * The HTTP status code the server sent.
+     */
+    private final int httpStatusCode;
+
+    /**
+     * Create a new wrapper for the given {@link GAException}, with the provided HTTP status code.
+     *
+     * @param cause          the {@link GAException} we're wrapping
+     * @param httpStatusCode the HTTP status code, which should never be 200 (== OK),
+     *                       considering that this is an <i>exception</i>
+     */
+    public GAWrapperException(GAException cause, int httpStatusCode) {
+        this.cause = cause;
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    /**
+     * Return the HTTP status code.
+     * @return the HTTP status code
+     */
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    /**
+     * Gets the value of the 'errorCode' field.
+     * @return The numerical error code
+     */
+    @Override
+    public Integer getErrorCode() {
+        return cause.getErrorCode();
+    }
+
+    /**
+     * Return the exception's message.
+     * @return the exception's message
+     */
+    @Override
+    public String getMessage() {
+        return cause.getMessage$();
+    }
+
+    /**
+     * Return the wrapped {@link GAException}.
+     * @return the wrapped {@link GAException}
+     */
+    @Override
+    public GAException getCause() {
+        return cause;
+    }
+}

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/RespCode.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/RespCode.java
@@ -29,20 +29,41 @@ public enum RespCode {
         this.code=value;
     }
 
-    public static RespCode fromInt(int val){
-        for(RespCode rc : values()){
-            if(rc.code == val){
+    /**
+     * Convert the HTTP status code to a {@link RespCode} value.
+     * @param code the HTTP status code
+     * @return the corresponding {@link RespCode}, or {@link #NOT_IMPLEMENTED} if not present
+     */
+    public static RespCode fromInt(int code) {
+        for (RespCode rc : values()) {
+            if (rc.code == code) {
                 return rc;
             }
         }
-        org.slf4j.LoggerFactory.getLogger("org.ga4gh.ctk.transport.RespCode")
-                .warn("Unexpected value lookup for RespCode: "+ val);
+        org.slf4j.LoggerFactory.getLogger(RespCode.class.getName())
+                               .warn("Unexpected value lookup for RespCode: " + code);
         return NOT_IMPLEMENTED;
     }
 
-    public static boolean isKnownResponse(int val){
-        for (RespCode rc : values())
-            if(rc.code == val) return true;
+    /**
+     * Return true if the provided code can be mapped to a value in the {@link RespCode} enum.
+     * @param code the HTTP response code
+     * @return true if the provided code can be mapped to a value in the {@link RespCode} enum
+     */
+    public static boolean isKnownResponse(int code) {
+        for (RespCode rc : values()) {
+            if (rc.code == code) {
+                return true;
+            }
+        }
         return false;
+    }
+
+    /**
+     * Return the numeric code.
+     * @return the numeric code
+     */
+    public int getCode() {
+        return code;
     }
 }

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
@@ -284,7 +284,6 @@ public class Client {
          */
         @Override
         public SearchReadGroupSetsResponse searchReadGroupSets(SearchReadGroupSetsRequest request)
-
                 throws AvroRemoteException {
             String path = urls.getSearchReadGroupSets();
             // we use an empty concrete response class to pass into the Parameterized AvroJson
@@ -340,8 +339,8 @@ public class Client {
          * @throws AvroRemoteException if there's a communication problem
          */
         @Override
-        public SearchDatasetsResponse searchDatasets(SearchDatasetsRequest request) throws
-                AvroRemoteException {
+        public SearchDatasetsResponse searchDatasets(SearchDatasetsRequest request)
+                throws AvroRemoteException {
             String path = urls.getSearchDatasets();
             SearchDatasetsResponse response = new SearchDatasetsResponse();
             final AvroJson aj =

--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -1,7 +1,13 @@
 package org.ga4gh.cts.api;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
 import org.ga4gh.models.Reference;
 import org.ga4gh.models.ReferenceSet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This class defines important constants that pertain to and describe the official test data.
@@ -32,20 +38,28 @@ public class TestData {
      * The names of the readgroup sets in the standard compliance dataset.
      */
     public static final String[] EXPECTED_READGROUPSETS_NAMES = {
-            "compliance-dataset1:1kg-low-coverage",
-            "compliance-dataset1:wgBam",
+            "1kg-low-coverage",
     };
 
     /**
      * The names of known-good read groups.
      */
-    public static final String[] SOME_EXPECTED_READGROUP_NAMES = {
-            "compliance-dataset1:wgBam:wgEncodeUwRepliSeqBg02esG1bAlnRep1_sample",
-            "compliance-dataset1:wgBam:wgEncodeUwRepliSeqBg02esG2AlnRep1_sample",
-            "compliance-dataset1:1kg-low-coverage:HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522",
-            "compliance-dataset1:1kg-low-coverage:HG00533.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522",
-            "compliance-dataset1:1kg-low-coverage:HG00534.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522",
-    };
+    public static final SetMultimap<String, String> EXPECTED_READGROUPSET_READGROUP_NAMES =
+            HashMultimap.create();
+
+    static {
+        EXPECTED_READGROUPSET_READGROUP_NAMES.putAll("1kg-low-coverage",
+                                                     Arrays.asList("BRCA1_HG00096",
+                                                                   "BRCA1_HG00099",
+                                                                   "BRCA1_HG00101"));
+    }
+
+    /**
+     * The names of all known {@link org.ga4gh.models.ReadGroup} objects, obtained from
+     * {@link #EXPECTED_READGROUPSET_READGROUP_NAMES}.
+     */
+    public static final List<String> EXPECTED_READGROUP_NAMES =
+            new ArrayList<>(EXPECTED_READGROUPSET_READGROUP_NAMES.values());
 
     /**
      * The names of all {@link ReferenceSet}s.

--- a/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
@@ -1,11 +1,16 @@
 package org.ga4gh.cts.api;
 
+import org.assertj.core.api.ThrowableAssert;
+import org.ga4gh.ctk.transport.GAWrapperException;
 import org.ga4gh.models.Program;
 import org.ga4gh.models.ReadAlignment;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import static org.assertj.core.api.StrictAssertions.catchThrowable;
 
 /**
  * Handy test-related static methods and data.
@@ -77,10 +82,31 @@ public class Utils {
     /**
      * Create and return an ID that's (virtually) guaranteed not to name a real object on a
      * GA4GH server.  It uses {@link UUID#randomUUID()} to do it.
+     * This is identical to {@link #randomName()} but for the name.
      * @return an ID that's (virtually) guaranteed not to name a real object
      */
     public static String randomId() {
         return UUID.randomUUID().toString();
     }
 
+
+    /**
+     * Create and return a name that's (virtually) guaranteed not to name a real object on a
+     * GA4GH server.  It uses {@link UUID#randomUUID()} to do it.
+     * This is identical to {@link #randomId()} but for the name.
+     * @return a name that's (virtually) guaranteed not to name a real object
+     */
+    public static String randomName() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Convenience method to catch a {@link GAWrapperException} and cast the return value to that type.
+     * @param shouldRaiseThrowable the {@link Callable} we're calling
+     * @return the {@link Throwable} thrown in the execution of the {@link Callable}
+     */
+    public static GAWrapperException catchGAWrapperException(ThrowableAssert.ThrowingCallable
+                                                                      shouldRaiseThrowable) {
+        return (GAWrapperException)catchThrowable(shouldRaiseThrowable);
+    }
 }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
@@ -36,19 +36,22 @@ public class DatasetsSearchIT {
 
         final Dataset dataset = datasets.get(0);
         assertThat(dataset).isNotNull();
+        // XXX this is no longer meaningful
         assertThat(dataset.getId()).isEqualTo(TestData.getDatasetId());
     }
 
     @Test
-    public void fetchDatasetByName() throws AvroRemoteException {
+    public void fetchDatasetById() throws AvroRemoteException {
+        // XXX getDataset isn't implemented on the ref server
         final Dataset dataset = client.reads.getDataset(TestData.getDatasetId());
         assertThat(dataset).isNotNull();
         assertThat(dataset.getId()).isEqualTo(TestData.getDatasetId());
     }
 
     @Test
-    public void fetchDatasetWithBogusName() throws AvroRemoteException {
+    public void fetchDatasetWithBogusId() throws AvroRemoteException {
         final String nonexistentDatasetId = Utils.randomId();
+        // XXX getDataset isn't implemented on the ref server
         final Dataset dataset = client.reads.getDataset(nonexistentDatasetId);
         assertThat(dataset).isNull();
     }
@@ -60,6 +63,7 @@ public class DatasetsSearchIT {
         final List<Dataset> datasets = resp.getDatasets();
 
         for (Dataset ds : datasets) {
+            // XXX getDataset isn't implemented on the ref server
             final Dataset dataset = client.reads.getDataset(ds.getId());
             assertThat(ds).isEqualTo(dataset);
         }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
@@ -1,6 +1,7 @@
 package org.ga4gh.cts.api.datasets;
 
 import org.apache.avro.AvroRemoteException;
+import org.ga4gh.ctk.transport.GAWrapperException;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
@@ -11,9 +12,11 @@ import org.ga4gh.models.Dataset;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.net.HttpURLConnection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ga4gh.cts.api.Utils.catchGAWrapperException;
 
 /**
  * Tests dealing with searching for datasets.
@@ -48,12 +51,20 @@ public class DatasetsSearchIT {
         assertThat(dataset.getId()).isEqualTo(TestData.getDatasetId());
     }
 
+    /**
+     * Try to fetch a dataset with a bogus ID and make sure it fails.
+     * @throws AvroRemoteException if something goes wrong
+     */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     @Test
     public void fetchDatasetWithBogusId() throws AvroRemoteException {
         final String nonexistentDatasetId = Utils.randomId();
-        // XXX getDataset isn't implemented on the ref server
-        final Dataset dataset = client.reads.getDataset(nonexistentDatasetId);
-        assertThat(dataset).isNull();
+
+        // this should throw a "no such dataset" GAException
+        final GAWrapperException didThrow =
+                catchGAWrapperException(() -> client.reads.getDataset(nonexistentDatasetId));
+
+        assertThat(didThrow.getHttpStatusCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
     }
 
     @Test

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsGetByIdIT.java
@@ -4,6 +4,7 @@ import org.apache.avro.AvroRemoteException;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
+import org.ga4gh.methods.GAException;
 import org.ga4gh.methods.SearchReadGroupSetsRequest;
 import org.ga4gh.methods.SearchReadGroupSetsResponse;
 import org.ga4gh.models.ReadGroupSet;
@@ -26,7 +27,7 @@ public class ReadGroupSetsGetByIdIT {
      * Check that the {@link ReadGroupSet}s we get via search (1) have valid IDs in them; (2)
      * those IDs can be used to fetch identical {@link ReadGroupSet}s.
      *
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void testGetByIdMatchesSearch() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsSearchIT.java
@@ -3,6 +3,7 @@ package org.ga4gh.cts.api.reads;
 import junitparams.JUnitParamsRunner;
 import org.apache.avro.AvroRemoteException;
 import org.ga4gh.ctk.CtkLogs;
+import org.ga4gh.ctk.transport.GAWrapperException;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
@@ -10,7 +11,6 @@ import org.ga4gh.cts.api.Utils;
 import org.ga4gh.methods.GAException;
 import org.ga4gh.methods.SearchReadGroupSetsRequest;
 import org.ga4gh.methods.SearchReadGroupSetsResponse;
-import org.ga4gh.methods.SearchReadGroupSetsResponseAssert;
 import org.ga4gh.models.Program;
 import org.ga4gh.models.ReadGroup;
 import org.ga4gh.models.ReadGroupSet;
@@ -18,10 +18,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.ga4gh.cts.api.Utils.catchGAWrapperException;
 
 /**
  * <p>Validates the data returned by /readgroupsets/search.</p>
@@ -66,42 +68,42 @@ public class ReadGroupSetsSearchIT implements CtkLogs {
 
     /**
      * <p>When we supply a bogus name to {@link SearchReadGroupSetsRequest}, because the
-     * returned objects must all have names that match, we expect an empty result.</p>
+     * returned objects must all have names that match, we expect NOT_FOUND.</p>
      * <p>The Schemas documentation says
      * that a {@link SearchReadGroupSetsRequest} always matches names exactly.</p>
      *
      * @throws AvroRemoteException the exception thrown
      */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     @Test
-    public void readGroupSetsNonexistentNameShouldMatchNothing() throws AvroRemoteException {
+    public void readGroupSetsNonexistentNameShouldSayNotFound() throws AvroRemoteException {
         // try to fetch a read group set with a name the server can't match
         final SearchReadGroupSetsRequest badNameReq =
                 SearchReadGroupSetsRequest.newBuilder()
                                           .setDatasetId(TestData.getDatasetId())
                                           .setName(Utils.randomName())
                                           .build();
-        final SearchReadGroupSetsResponse badNameResp = client.reads.searchReadGroupSets(badNameReq);
-        final List<ReadGroupSet> emptyReadGroupSets = badNameResp.getReadGroupSets();
-        assertThat(emptyReadGroupSets).isEmpty();
+        final GAWrapperException t = catchGAWrapperException(() -> client.reads.searchReadGroupSets(badNameReq));
+        assertThat(t.getHttpStatusCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
     }
 
     /**
-     * <p>Readgroup set response for a nonexistent dataset ID should be empty.</p>
+     * <p>Readgroup set response for a nonexistent dataset ID should be NOT_FOUND.</p>
      *
      * <p>Pass in a well-formed but non-matching dataset ID to a SearchReadGroupSetsRequest
      * expect a valid SearchReadGroupSetsResponse with no ReadGroupSets in it.</p>
      *
      * @throws AvroRemoteException the exception thrown
      */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     @Test
     public void readgroupSetResponseForNonexistentDatasetIdShouldReturnEmptyList() throws AvroRemoteException {
         SearchReadGroupSetsRequest reqb =
                 SearchReadGroupSetsRequest.newBuilder()
                                           .setDatasetId(Utils.randomId())
                                           .build();
-        SearchReadGroupSetsResponse rtnVal = client.reads.searchReadGroupSets(reqb);
-        // avro says always get a 200
-        SearchReadGroupSetsResponseAssert.assertThat(rtnVal).isNotNull().hasNoReadGroupSets();
+        final GAWrapperException t = catchGAWrapperException(() -> client.reads.searchReadGroupSets(reqb));
+        assertThat(t.getHttpStatusCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
     }
 
     /**

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupsGetByIdIT.java
@@ -4,6 +4,7 @@ import org.apache.avro.AvroRemoteException;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
+import org.ga4gh.methods.GAException;
 import org.ga4gh.methods.SearchReadGroupSetsRequest;
 import org.ga4gh.methods.SearchReadGroupSetsResponse;
 import org.ga4gh.models.ReadGroup;
@@ -27,7 +28,7 @@ public class ReadGroupsGetByIdIT {
      * Check that the {@link ReadGroup}s we get via search (1) have valid IDs in them; (2)
      * those IDs can be used to fetch identical {@link ReadGroup}s.
      *
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void testGetByIdMatchesSearch() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadMethodsEndpointAliveIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadMethodsEndpointAliveIT.java
@@ -138,7 +138,7 @@ public class ReadMethodsEndpointAliveIT implements CtkLogs {
                                   .setReferenceId(refId)
                                   .build();
 
-        GAWrapperException t =
+        final GAWrapperException t =
                 catchGAWrapperException(() -> client.reads.searchReads(searchReadsReq));
         assertThat(t.getHttpStatusCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
     }
@@ -177,7 +177,7 @@ public class ReadMethodsEndpointAliveIT implements CtkLogs {
                 SearchReadsRequest.newBuilder()
                                   .setReadGroupIds(Arrays.asList(replacedReadGroupId.split(";")))
                                   .build();
-        GAWrapperException e = catchGAWrapperException(() -> client.reads.searchReads(srr));
+        final GAWrapperException e = catchGAWrapperException(() -> client.reads.searchReads(srr));
         assertThat(e.getHttpStatusCode()).isEqualTo(expStatus.getCode());
     }
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
@@ -6,15 +6,11 @@ import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
 import org.ga4gh.cts.api.Utils;
-import org.ga4gh.methods.SearchReadGroupSetsRequest;
-import org.ga4gh.methods.SearchReadGroupSetsResponse;
-import org.ga4gh.methods.SearchReadsRequest;
-import org.ga4gh.methods.SearchReadsResponse;
+import org.ga4gh.methods.*;
 import org.ga4gh.models.*;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,7 +45,7 @@ public class ReadsSearchIT implements CtkLogs {
      * alignment of type {@link LinearAlignment} with field cigar holding a {@link CigarUnit}.</li>
      * </ul>
      *
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void searchReads() throws AvroRemoteException {
@@ -131,7 +127,7 @@ public class ReadsSearchIT implements CtkLogs {
     public void searchReadsWithAllNamesReturnsAllMatching() throws Exception {
         final SearchReadsRequest request =
                 SearchReadsRequest.newBuilder()
-                                  .setReadGroupIds(Arrays.asList(TestData.SOME_EXPECTED_READGROUP_NAMES))
+                                  .setReadGroupIds(TestData.EXPECTED_READGROUP_NAMES)
                                   .build();
         final SearchReadsResponse response = client.reads.searchReads(request);
 
@@ -151,7 +147,7 @@ public class ReadsSearchIT implements CtkLogs {
      */
     @Test
     public void readsResponseMatchesACTGNPattern() throws Exception {
-        for (String readGroupName : TestData.SOME_EXPECTED_READGROUP_NAMES) {
+        for (String readGroupName : TestData.EXPECTED_READGROUP_NAMES) {
             SearchReadsRequest request = SearchReadsRequest.newBuilder()
                                                            .setReadGroupIds(aSingle(readGroupName))
                                                            .build();

--- a/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceBasesSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceBasesSearchIT.java
@@ -6,10 +6,7 @@ import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.Utils;
 import org.ga4gh.cts.api.reads.ReadsTests;
-import org.ga4gh.methods.ListReferenceBasesRequest;
-import org.ga4gh.methods.ListReferenceBasesResponse;
-import org.ga4gh.methods.SearchReferencesRequest;
-import org.ga4gh.methods.SearchReferencesResponse;
+import org.ga4gh.methods.*;
 import org.ga4gh.models.Reference;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,7 +33,7 @@ public class ReferenceBasesSearchIT {
      * that each returned {@link Reference} has a valid(-looking) MD5.  (In the future, perhaps this
      * test should compute the MD5 and compare it to what's returned.)
      *
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void getAllReferencesWithEmptyMd5List() throws AvroRemoteException {
@@ -65,7 +62,7 @@ public class ReferenceBasesSearchIT {
      *     <li>Test 2: assert that we received a {@link Reference} object with fields
      *     <pre>offset == 150 AND sequence == "ACCCTAACCC"</pre></li>
      * </ul>
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void searchForExpectedReferenceBases() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceSetsSearchIT.java
@@ -5,6 +5,7 @@ import org.apache.avro.AvroRemoteException;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.reads.ReadsTests;
+import org.ga4gh.methods.GAException;
 import org.ga4gh.methods.SearchReferenceSetsRequest;
 import org.ga4gh.methods.SearchReferenceSetsResponse;
 import org.ga4gh.models.ReferenceSet;
@@ -39,7 +40,7 @@ public class ReferenceSetsSearchIT {
      * <li>Query 2: <pre>/referencesets/(ref set ID)</pre></li>
      * <li>Test 2: assert that the ID of the returned object == ref set ID above.</li>
      * </ul>
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void searchForExpectedReferenceSets() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferencesSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferencesSearchIT.java
@@ -6,6 +6,7 @@ import org.assertj.core.api.StrictAssertions;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.variants.VariantsTests;
+import org.ga4gh.methods.GAException;
 import org.ga4gh.methods.SearchReferencesRequest;
 import org.ga4gh.methods.SearchReferencesResponse;
 import org.ga4gh.models.Reference;
@@ -41,7 +42,7 @@ public class ReferencesSearchIT {
      * <li>Query 2: <pre>/references/(ref ID)</pre></li>
      * <li>Test 2: assert that the returned {@link Reference} has <pre>ID == ref ID</pre></li>
      * </ul>
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void searchForExpectedReferences() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -6,6 +6,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.avro.AvroRemoteException;
 import org.ga4gh.ctk.CtkLogs;
+import org.ga4gh.ctk.transport.GAWrapperException;
 import org.ga4gh.ctk.transport.TransportUtils;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
@@ -194,16 +195,18 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
     }
 
     /**
-     * Test getting a call set with an invalid ID.
+     * Test getting a call set with an invalid ID.  It should fail with NOT_FOUND.
      * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     @Test
     public void getCallSetWithInvalidIDShouldFail() throws AvroRemoteException {
         final String nonexistentCallSetId = Utils.randomId();
 
         // fetch the CallSet with that ID
-        final CallSet callSetFromGet = client.variants.getCallSet(nonexistentCallSetId);
-        assertThat(callSetFromGet).isNull();
+        final GAWrapperException t =
+                Utils.catchGAWrapperException(() -> client.variants.getCallSet(nonexistentCallSetId));
+        assertThat(t.getHttpStatusCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
     }
 
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -11,10 +11,7 @@ import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
 import org.ga4gh.cts.api.Utils;
-import org.ga4gh.methods.SearchCallSetsRequest;
-import org.ga4gh.methods.SearchCallSetsResponse;
-import org.ga4gh.methods.SearchVariantSetsRequest;
-import org.ga4gh.methods.SearchVariantSetsResponse;
+import org.ga4gh.methods.*;
 import org.ga4gh.models.CallSet;
 import org.ga4gh.models.VariantSet;
 import org.junit.Test;
@@ -135,7 +132,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
      * that it contains &gt; 0 {@link CallSet} objects. We can check that the call sets have
      * distinct ID values.</li>
      * </ul>
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void searchForExpectedCallSets() throws AvroRemoteException {
@@ -161,7 +158,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
 
     /**
      * Test getting a call set with a valid ID.
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void getCallSetWithValidIDShouldSucceed() throws AvroRemoteException {
@@ -198,7 +195,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
 
     /**
      * Test getting a call set with an invalid ID.
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void getCallSetWithInvalidIDShouldFail() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
@@ -6,6 +6,7 @@ import org.ga4gh.ctk.CtkLogs;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
+import org.ga4gh.methods.GAException;
 import org.ga4gh.methods.SearchVariantSetsRequest;
 import org.ga4gh.methods.SearchVariantSetsResponse;
 import org.ga4gh.models.VariantSet;
@@ -38,7 +39,7 @@ public class VariantSetsSearchIT implements CtkLogs {
      * <li>Test 2: assert that the 'metadata' field of that {@link VariantSet} is of type
      * {@link VariantSetMetadata}.</li>
      * </ul>
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void searchVariantSets() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsGetByIdIT.java
@@ -5,10 +5,7 @@ import org.apache.avro.AvroRemoteException;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
-import org.ga4gh.methods.SearchVariantSetsRequest;
-import org.ga4gh.methods.SearchVariantSetsResponse;
-import org.ga4gh.methods.SearchVariantsRequest;
-import org.ga4gh.methods.SearchVariantsResponse;
+import org.ga4gh.methods.*;
 import org.ga4gh.models.Variant;
 import org.ga4gh.models.VariantSet;
 import org.junit.Test;
@@ -33,7 +30,7 @@ public class VariantsGetByIdIT {
     /**
      * Verify that Variants that we obtain by way of {@link SearchVariantsRequest} match the ones
      * we get via <tt>GET /variants/{id}</tt>.
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void checkVariantsGetResultsMatchSearchResults() throws AvroRemoteException {

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsSearchIT.java
@@ -5,10 +5,7 @@ import org.ga4gh.ctk.CtkLogs;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
-import org.ga4gh.methods.SearchVariantSetsRequest;
-import org.ga4gh.methods.SearchVariantSetsResponse;
-import org.ga4gh.methods.SearchVariantsRequest;
-import org.ga4gh.methods.SearchVariantsResponse;
+import org.ga4gh.methods.*;
 import org.ga4gh.models.Call;
 import org.ga4gh.models.Variant;
 import org.ga4gh.models.VariantSet;
@@ -42,7 +39,7 @@ public class VariantsSearchIT implements CtkLogs {
      * <li>Test 4: assert that the <tt>genotype</tt> field of the first {@link Call} is an array
      * of integers.</li>
      * </ul>
-     * @throws AvroRemoteException if there's a communication problem
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
     public void searchForExpectedVariants() throws AvroRemoteException {

--- a/test-data/convert_to_binary.sh
+++ b/test-data/convert_to_binary.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# exit on any error
+set -e
+
+##
+### references
+##
+
+# zip prepare the reference(s) with bgzip
+bgzip -c hs37d5_chr17_41196312-41277500.fa > hs37d5_chr17_41196312-41277500.fa.gz
+
+# index with samtools
+samtools faidx hs37d5_chr17_41196312-41277500.fa.gz
+
+##
+### variants
+##
+
+# zip with bgzip
+bgzip -c 1000g_offset.HG00096_HG00099_HG00101.2010502.17_41196312-41277500.vcf > 1000g_offset.HG00096_HG00099_HG00101.2010502.17_41196312-41277500.vcf.gz
+
+# index with tabix
+tabix -p vcf 1000g_offset.HG00096_HG00099_HG00101.2010502.17_41196312-41277500.vcf.gz
+
+##
+### reads
+##
+
+# make bam files from sam files
+samtools view -b -h -o BRCA1_HG00096.bam BRCA1_HG00096_hg37_offset.sam
+samtools view -b -h -o BRCA1_HG00099.bam BRCA1_HG00099_hg37_offset.sam
+samtools view -b -h -o BRCA1_HG00101.bam BRCA1_HG00101_hg37_offset.sam
+
+# index bam files with samtools
+for b in *.bam; do
+    samtools index $b
+done
+
+echo Conversion complete.


### PR DESCRIPTION
Prior to this PR, tests needed to use a special `WireTracker` object to monitor a request and check if it generated an exception.
This change makes it so that server requests can now throw `GAException`, just as you'd expect.
You can capture the thrown exception and test the `errorCode`, message, etc.
In addition, you can get the request's HTTP status code from the exception object.  Many tests need to test this value.
