### PR TITLE
CallSets paging tests; fixed ReadGroup and ReadGroupSet names

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -1,6 +1,7 @@
 package org.ga4gh.cts.api;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multiset;
 import com.google.common.collect.SetMultimap;
 import org.ga4gh.models.ReferenceSet;
 
@@ -52,24 +53,29 @@ public class TestData {
     public static final long REFERENCE_END = 81187;
 
     /**
-     * The names of the readgroup sets in the standard compliance dataset.
-     */
-    public static final String[] EXPECTED_READGROUPSETS_NAMES = {
-            "1kg-low-coverage",
-    };
-
-    /**
      * The names of known-good read groups.
      */
     public static final SetMultimap<String, String> EXPECTED_READGROUPSET_READGROUP_NAMES =
             HashMultimap.create();
 
     static {
-        EXPECTED_READGROUPSET_READGROUP_NAMES.putAll("1kg-low-coverage",
-                                                     Arrays.asList("BRCA1_HG00096",
-                                                                   "BRCA1_HG00099",
-                                                                   "BRCA1_HG00101"));
+        EXPECTED_READGROUPSET_READGROUP_NAMES.putAll("BRCA1_HG00096.bam",
+                                                     Arrays.asList("SRR062634",
+                                                                   "SRR062635",
+                                                                   "SRR062641"));
+        EXPECTED_READGROUPSET_READGROUP_NAMES.putAll("BRCA1_HG00099.bam",
+                                                     Arrays.asList("SRR741411",
+                                                                   "SRR741412"));
+        //noinspection ArraysAsListWithZeroOrOneArgument
+        EXPECTED_READGROUPSET_READGROUP_NAMES.putAll("BRCA1_HG00101.bam",
+                                                     Arrays.asList("ERR229776"));
     }
+
+    /**
+     * The names of the readgroup sets in the standard compliance dataset.
+     */
+    public static final Multiset<String> EXPECTED_READGROUPSETS_NAMES =
+            EXPECTED_READGROUPSET_READGROUP_NAMES.keys();
 
     /**
      * The names of all known {@link org.ga4gh.models.ReadGroup} objects, obtained from

--- a/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
@@ -289,6 +289,24 @@ public class Utils {
     }
 
     /**
+     * Search for and return all {@link CallSet}s in the {@link VariantSet} named by <tt>variantSetId</tt>.
+     *
+     * @param client the connection to the server
+     * @param variantSetId the ID of the {@link VariantSet}
+     * @return the {@link List} of results
+     * @throws AvroRemoteException if the server throws an exception or there's an I/O error
+     */
+    public static List<CallSet> getAllCallSets(Client client,
+                                               String variantSetId) throws AvroRemoteException {
+        final SearchCallSetsRequest callSetsSearchRequest =
+                SearchCallSetsRequest.newBuilder()
+                                     .setVariantSetId(variantSetId)
+                                     .build();
+        final SearchCallSetsResponse csResp = client.variants.searchCallSets(callSetsSearchRequest);
+        return csResp.getCallSets();
+    }
+
+    /**
      * Convenience method to catch a {@link GAWrapperException} and cast the return value to that type.
      * @param shouldRaiseThrowable the {@link Callable} we're calling
      * @return the {@link Throwable} thrown in the execution of the {@link Callable}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
@@ -103,27 +103,31 @@ public class ReadsSearchIT implements CtkLogs {
     }
 
     /**
-     * The <tt>searchReadGroupSets</tt> operation must return {@link ReadGroupSet}s with expected names.
-     * (Adapted from an old JavaScript test.)
+     * Fetch every {@link ReadGroupSet} named in {@link TestData#EXPECTED_READGROUP_NAMES} using
+     * <tt>searchReadGroupSets</tt> and verify that it returns the expected {@link ReadGroupSet}.
      *
      * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
      */
     @Test
-    public void searchReadGroupSetsMustReturnReadGroupSetsWithExpectedNames() throws AvroRemoteException {
+    public void searchReadGroupSetsMustReturnReadGroupSetsWithExpectedNames() throws
+            AvroRemoteException {
 
-        final String expectedReadGroupSetName = TestData.EXPECTED_READGROUPSETS_NAMES[0];
+        for (String expectedReadGroupSetName : TestData.EXPECTED_READGROUPSETS_NAMES) {
 
-        final SearchReadGroupSetsRequest req =
-                SearchReadGroupSetsRequest.newBuilder()
-                                          .setDatasetId(TestData.getDatasetId())
-                                          .build();
-        final SearchReadGroupSetsResponse resp = client.reads.searchReadGroupSets(req);
+            final SearchReadGroupSetsRequest req =
+                    SearchReadGroupSetsRequest.newBuilder()
+                                              .setDatasetId(TestData.getDatasetId())
+                                              .setName(expectedReadGroupSetName)
+                                              .build();
+            final SearchReadGroupSetsResponse resp = client.reads.searchReadGroupSets(req);
 
-        final List<ReadGroupSet> readGroupSets = resp.getReadGroupSets();
+            final List<ReadGroupSet> readGroupSets = resp.getReadGroupSets();
 
-        assertThat(readGroupSets).hasSize(1);
-        readGroupSets.stream()
-                     .forEach(rgs -> assertThat(rgs.getName()).isEqualTo(expectedReadGroupSetName));
+            assertThat(readGroupSets).hasSize(1);
+            final ReadGroupSet readGroupSet = readGroupSets.get(0);
+            assertThat(readGroupSet.getName()).isEqualTo(expectedReadGroupSetName);
+            assertThat(readGroupSet.getDatasetId()).isEqualTo(TestData.getDatasetId());
+        }
     }
 
     /**

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallSetsPagingIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallSetsPagingIT.java
@@ -1,0 +1,147 @@
+package org.ga4gh.cts.api.variants;
+
+import junitparams.JUnitParamsRunner;
+import org.apache.avro.AvroRemoteException;
+import org.ga4gh.ctk.transport.URLMAPPING;
+import org.ga4gh.ctk.transport.protocols.Client;
+import org.ga4gh.cts.api.Utils;
+import org.ga4gh.methods.GAException;
+import org.ga4gh.methods.SearchCallSetsRequest;
+import org.ga4gh.methods.SearchCallSetsResponse;
+import org.ga4gh.models.CallSet;
+import org.ga4gh.models.VariantSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests paging through {@link CallSet}s.
+ *
+ * @author Herb Jellinek
+ */
+@RunWith(JUnitParamsRunner.class)
+@Category(VariantsTests.class)
+/**
+ */
+public class CallSetsPagingIT {
+
+    private static final URLMAPPING urls = URLMAPPING.getInstance();
+
+    private static Client client = new Client(urls);
+
+    /**
+     * Check that we can page 1 by 1 through the {@link CallSet}s we receive from
+     * {@link org.ga4gh.ctk.transport.protocols.Client.Variants#searchCallSets(SearchCallSetsRequest)}.
+     *
+     * @throws AvroRemoteException if there's a communication problem or server exception
+     */
+    @Test
+    public void checkPagingOneByOneThroughCallSets() throws AvroRemoteException {
+
+        final String variantSetId = Utils.getVariantSetId(client);
+        final List<CallSet> allCallSets = Utils.getAllCallSets(client, variantSetId);
+        final Set<CallSet> setOfCallSets = new HashSet<>(allCallSets);
+
+        String pageToken = null;
+        for (CallSet ignored : allCallSets) {
+            final SearchCallSetsRequest pageReq =
+                    SearchCallSetsRequest.newBuilder()
+                                         .setVariantSetId(variantSetId)
+                                         .setPageSize(1)
+                                         .setPageToken(pageToken)
+                                         .build();
+            final SearchCallSetsResponse pageResp =
+                    client.variants.searchCallSets(pageReq);
+            final List<CallSet> pageOfCallSets = pageResp.getCallSets();
+            pageToken = pageResp.getNextPageToken();
+
+            assertThat(pageOfCallSets).hasSize(1);
+            assertThat(setOfCallSets).contains(pageOfCallSets.get(0));
+
+            setOfCallSets.remove(pageOfCallSets.get(0));
+        }
+
+        assertThat(pageToken).isNull();
+        assertThat(setOfCallSets).isEmpty();
+    }
+
+    /**
+     * Check that we can page through the {@link CallSet}s we receive from
+     * {@link org.ga4gh.ctk.transport.protocols.Client.Variants#searchCallSets(SearchCallSetsRequest)}
+     * using an increment as large as the non-paged set of results.
+     *
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
+     */
+    @Test
+    public void checkPagingByOneChunkThroughCallSets() throws AvroRemoteException {
+        final String variantSetId = Utils.getVariantSetId(client);
+        final List<CallSet> listOfCallSets = Utils.getAllCallSets(client, variantSetId);
+
+        // we don't care how many there are, as long as it's at least a few
+        assertThat(listOfCallSets.size()).isGreaterThanOrEqualTo(3);
+
+        // page through the variants in one gulp
+        checkSinglePageOfCallSets(variantSetId,
+                                  listOfCallSets.size(),
+                                  listOfCallSets);
+    }
+
+    /**
+     * Check that we can page through the variants we receive from
+     * {@link org.ga4gh.ctk.transport.protocols.Client.Variants#searchCallSets
+     * (SearchCallSetsRequest)}
+     * using an increment twice as large as the non-paged set of results.
+     *
+     * @throws AvroRemoteException if there's a communication problem or server exception ({@link
+     * GAException})
+     */
+    @Test
+    public void checkPagingByOneTooLargeChunkThroughCallSets() throws AvroRemoteException {
+        final String variantSetId = Utils.getVariantSetId(client);
+        final List<CallSet> listOfCallSets = Utils.getAllCallSets(client, variantSetId);
+
+        // we don't care how many there are, as long as it's at least a few
+        assertThat(listOfCallSets.size()).isGreaterThanOrEqualTo(3);
+
+        checkSinglePageOfCallSets(variantSetId,
+                                  listOfCallSets.size() * 2,
+                                  listOfCallSets);
+    }
+
+    /**
+     * Check that we can receive expected results when we request a single
+     * page of {@link CallSet}s from {@link org.ga4gh.ctk.transport.protocols.Client.Variants#searchCallSets(SearchCallSetsRequest)},
+     * using <tt>pageSize</tt> as the page size.
+     *
+     * @param variantSetId     the ID of the {@link VariantSet} we're paging through
+     * @param pageSize         the page size we'll request
+     * @param expectedCallSets all of the {@link CallSet} objects we expect to receive
+     *
+     * @throws AvroRemoteException if there's a communication problem or server exception
+     */
+    private void checkSinglePageOfCallSets(String variantSetId,
+                                           int pageSize,
+                                           List<CallSet> expectedCallSets) throws AvroRemoteException {
+
+        final SearchCallSetsRequest pageReq =
+                SearchCallSetsRequest.newBuilder()
+                                     .setVariantSetId(variantSetId)
+                                     .setPageSize(pageSize)
+                                     .build();
+        final SearchCallSetsResponse pageResp = client.variants.searchCallSets(pageReq);
+        final List<CallSet> pageOfCallSets = pageResp.getCallSets();
+        final String pageToken = pageResp.getNextPageToken();
+
+        assertThat(pageOfCallSets).hasSize(expectedCallSets.size());
+        assertThat(expectedCallSets).containsAll(pageOfCallSets);
+
+        assertThat(pageToken).isNull();
+    }
+
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/CallsetsSearchResponseCheckIT.java
@@ -71,7 +71,7 @@ public class CallsetsSearchResponseCheckIT implements CtkLogs {
 
         assertThat(vResp.getVariantSets()).isNotEmpty();
 
-        // grab the first VariantSet and use it as source of ReadSets
+        // grab the first VariantSet and use it as source of CallSets
         final VariantSet variantSet = vResp.getVariantSets().get(0);
         final String variantSetId = variantSet.getId();
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsPagingIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsPagingIT.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Herb Jellinek
  */
 @Category(VariantsTests.class)
-public class VariantsMethodsPagingIT implements CtkLogs {
+public class VariantsPagingIT implements CtkLogs {
 
     private static Client client = new Client(URLMAPPING.getInstance());
 
@@ -53,7 +53,7 @@ public class VariantsMethodsPagingIT implements CtkLogs {
 
         // page through the variants using the same query parameters
         String pageToken = null;
-        for (Variant v : listOfVariants) {
+        for (Variant ignored : listOfVariants) {
             final SearchVariantsRequest pageReq =
                     SearchVariantsRequest.newBuilder()
                                          .setVariantSetId(variantSetId)


### PR DESCRIPTION
I added `CallSet` paging tests and fixed the `ReadGroup` and `ReadGroupSet` names in class `TestData`.