### PR TITLE
Fix the test data reference set checksum

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -97,7 +97,7 @@ public class TestData {
     /**
      * MD5 checksum for the test {@link ReferenceSet}.
      */
-    public static final String REFERENCESET_MD5_CHECKSUM = "90977a37195d3fd247e4916b5b4cbae8";
+    public static final String REFERENCESET_MD5_CHECKSUM = "12827085103f42e97428dc05a7f26fec";
 
     /**
      * NCBI Taxonomy ID (identifies species) for the test {@link ReferenceSet} (the NCBI TaxonId for Homo Sapiens).


### PR DESCRIPTION
This is computed as `MD5("90977a37195d3fd247e4916b5b4cbae8")` per the [documentation](https://github.com/ga4gh/schemas/blob/master/src/main/resources/avro/references.avdl#L89).