### PR TITLE
Change expected refset taxon ID from string -> int

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -102,7 +102,7 @@ public class TestData {
     /**
      * NCBI Taxonomy ID (identifies species) for the test {@link ReferenceSet} (the NCBI TaxonId for Homo Sapiens).
      */
-    public static final String REFERENCESET_TAXON_ID = "9606";
+    public static final int REFERENCESET_TAXON_ID = 9606;
 
     /**
      * The name of the BRCA1 reference sequence.


### PR DESCRIPTION
This field has type `{null, int}` in the [schema](https://github.com/ga4gh/schemas/blob/master/src/main/resources/avro/references.avdl#L69).