### PR TITLE
Fix for #85: added logging to Utils.catchGAWrapperException

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.StrictAssertions.catchThrowable;
+import static org.assertj.core.api.StrictAssertions.fail;
 
 /**
  * Handy test-related static methods and data.
@@ -331,12 +332,22 @@ public class Utils {
 
     /**
      * Convenience method to catch a {@link GAWrapperException} and cast the return value to that type.
+     * <b>Only use this when you're expecting the enclosed code to throw that exception.</b>
+     * If the code we call doesn't throw the expected {@link GAWrapperException}, it calls
+     * {@link org.assertj.core.api.StrictAssertions#fail(String)} to cause the enclosing test to logg
+     * the stack trace.
      * @param shouldRaiseThrowable the {@link Callable} we're calling
      * @return the {@link Throwable} thrown in the execution of the {@link Callable}
      */
     public static GAWrapperException catchGAWrapperException(ThrowableAssert.ThrowingCallable
                                                                       shouldRaiseThrowable) {
-        return (GAWrapperException)catchThrowable(shouldRaiseThrowable);
+        final GAWrapperException maybeAnException =
+                (GAWrapperException)catchThrowable(shouldRaiseThrowable);
+        if (maybeAnException == null) {
+            // we were expecting an exception and didn't get one.  log it as a failure.
+            fail("Expected but did not receive GAWrapperException");
+        }
+        return maybeAnException;
     }
 
     /**

--- a/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsPagingIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsPagingIT.java
@@ -83,7 +83,7 @@ public class DatasetsPagingIT {
         final List<Dataset> listOfDatasets = Utils.getAllDatasets(client);
         assertThat(listOfDatasets).isNotEmpty();
 
-        // page through the reads in one gulp
+        // page through the datasets in one gulp
         checkSinglePageOfDatasets(listOfDatasets.size(),
                                   listOfDatasets);
     }
@@ -102,7 +102,7 @@ public class DatasetsPagingIT {
         final List<Dataset> listOfDatasets = Utils.getAllDatasets(client);
         assertThat(listOfDatasets).isNotEmpty();
 
-        // page through the reads in one too-large gulp
+        // page through the datasets in one too-large gulp
         checkSinglePageOfDatasets(listOfDatasets.size() * 2, listOfDatasets);
     }
 

--- a/cts-java/src/test/java/org/ga4gh/cts/core/CatchExceptionsIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/core/CatchExceptionsIT.java
@@ -1,0 +1,68 @@
+package org.ga4gh.cts.core;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.ga4gh.ctk.testcategories.CoreTests;
+import org.ga4gh.ctk.transport.GAWrapperException;
+import org.ga4gh.cts.api.Utils;
+import org.ga4gh.methods.GAException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test handling and logging exceptions.
+ *
+ * @author Herb Jellinek
+ */
+@Category(CoreTests.class)
+public class CatchExceptionsIT {
+
+    /**
+     * Wrap a piece of code that does not throw an exception in {@link Utils#catchGAWrapperException(ThrowableAssert.ThrowingCallable)}
+     * and make sure it doesn't assume it's an exception.
+     * <p>
+     * We expect this test always to fail under all circumstances, simply
+     * as a condition of how it's written.  We'll mark it with @Ignore so it doesn't look like a test that
+     * was expected to succeed failed.
+     * </p>
+     */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+    @Ignore("Exercises some logging and written always to fail, so no need to run it.")
+    @Test
+    public void testHandlingNonException() {
+        // this should log an error also
+        GAWrapperException e = Utils.catchGAWrapperException(this::doNotThrowGAWrapperException);
+        assertThat(e).isNull();
+    }
+
+    /**
+     * Wrap a piece of code that throws an exception in {@link Utils#catchGAWrapperException(ThrowableAssert.ThrowingCallable)}
+     * and make sure it logs it.
+     */
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+    @Test
+    public void testHandlingException() {
+        GAWrapperException e = Utils.catchGAWrapperException(this::throwGAWrapperException);
+        assertThat(e).isNotNull();
+        assertThat(e.getHttpStatusCode()).isEqualTo(HttpURLConnection.HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Like it says on the tin: do not throw an exception.  In fact, do nothing.
+     */
+    private void doNotThrowGAWrapperException() {
+        // do nothing
+    }
+
+    /**
+     * Throw a {@link GAWrapperException}.
+     */
+    private void throwGAWrapperException() throws GAWrapperException {
+        throw new GAWrapperException(new GAException("synthetic"), HttpURLConnection.HTTP_NOT_FOUND);
+    }
+
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/core/DatasetIdPropertyIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/core/DatasetIdPropertyIT.java
@@ -1,8 +1,10 @@
 package org.ga4gh.cts.core;
 
+import org.ga4gh.ctk.testcategories.CoreTests;
 import org.ga4gh.cts.api.TestData;
 import org.ga4gh.cts.api.Utils;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Herb Jellinek
  */
+@Category(CoreTests.class)
 public class DatasetIdPropertyIT {
 
     private static final String PROP_NAME = "ctk.tgt.dataset_id";


### PR DESCRIPTION
`Utils.catchGAWrapperException` now calls `fail()` when the enclosed code doesn't throw `GAWrapperException`.