### PR TITLE
Fix for #88.

### DIFF
--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java
@@ -98,7 +98,7 @@ public interface URLMAPPING {
 
     /**
      * <p>Initialize URLMAPPING.</p>
-     * <p>Given a resource name, this looks loads (in order):
+     * <p>Given a resource name, this loads (in order):
      * <ul>
      * <li>a properties file of that name on the classpath</li>
      * <li>a properties file of that name from the file system</li>

--- a/cts-java/src/test/java/org/ga4gh/cts/api/endpoints/RawEndpointsIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/endpoints/RawEndpointsIT.java
@@ -6,6 +6,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.ga4gh.ctk.transport.TransportUtils;
 import org.ga4gh.ctk.transport.URLMAPPING;
+import org.ga4gh.ctk.transport.protocols.Client;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -60,7 +61,9 @@ public class RawEndpointsIT {
     }
 
     /**
-     * Test that searches' verbs/methods work as expected.
+     * Test that searches' verbs/methods work as expected.  Because our usual {@link Client} object
+     * only creates well-formed requests, we use Unirest, a simple REST client API,
+     * to connect to the server.
      *
      * @param fullUrl the URL to test
      */
@@ -71,7 +74,7 @@ public class RawEndpointsIT {
             assertThat(Unirest.post(fullUrl)
                               .header("Content-type", "application/json")
                               .body(datum)
-                              .asBinary()
+                              .asBinary() // make the request; we don't really care about the format
                               .getStatus()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
         }
     }


### PR DESCRIPTION
Now this only tests what happens when you POST a bad payload to a search endpoint.
Also added a couple of missing search endpoints.