### PR TITLE
Some documentation fixes (squashed)

### DIFF
--- a/docs/ArchitectureOverview.md
+++ b/docs/ArchitectureOverview.md
@@ -12,7 +12,7 @@ customized to the GA4GH domain objects. Here's an example testcase:
 ```java
 
 	@Test
-    @Parameters({{"low-coverage:HG00533.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522"})
+    @Parameters({"low-coverage:HG00533.mapped.ILLUMINA.bwa.CHS.low_coverage.20120522"})
     public void readsResponseMatchesACTGNPattern(String rgid) throws Exception {
         // do a readsearch
         GASearchReadsRequest gsrr = GASearchReadsRequest.newBuilder()

--- a/docs/ConfigTheCTK.md
+++ b/docs/ConfigTheCTK.md
@@ -6,14 +6,14 @@ need to edit this file.
 
 You can configure the CTK via the properties used by the:
 
-- `transport` module to control target server URLS (see `/transport/src/main/resources/defaulttransport.properties/`
+- `transport` module to control target server URLS (edit `cts-java/src/main/resources/defaulttransport.properties` and `ctk-transport/src/main/resources/defaulttransport.properties`)
 - `ctk-cli` module to control:
 	- test selection and some infrequently-changed items general operation (loader paths etc) (see `/ctk-cli/src/main/resources/application.properties`)
 	- logging behavior (see `/ctk-cli/src/main/resources/log4j2.xml`)
 - `cts-java` has its own copy of `defaulttransport.properties` to support running stand-alone tests under IDEs, this is still experimental and may be removed.
 
 
-If you're working with CTK/CTS source (in an IDE or for a Maven build) it's easiest to just edit `ctk-cli/src/main/resources/application.properties` and `ctk-cli/src/main/resources/application.properties` but these changes will have no effect until you rebuild (because the rebuild copies the files from `src/main/resources/` into `target/` which is where the code runs from). But, you can make temporary changes to the text properties files directly in the output build `target` tree.
+If you're working with CTK/CTS source (in an IDE or for a Maven build) it's easiest to just edit `ctk-cli/src/main/resources/application.properties`, `ctk-server/src/main/resources/application.properties`, and `ctk-testrunner/src/main/resources/application.properties`, but these changes will have no effect until you rebuild (because the rebuild copies the files from `src/main/resources/` into `target/` which is where the code runs from). But, you can make temporary changes to the text properties files directly in the output build `target` tree.
 
 If you're working with the CTK/CTS at the command line, you can extract that file from the packaged jar file and have it in the dir where the jar runs from
 (`jar xvf ctk-cli-v.0.5.1-SNAPSHOT.jar application.properties`) ... if you're using the ZIP distribution, it will already have extracted that properties file (and other control files) for you.
@@ -33,9 +33,9 @@ The CTK also sends test-specific data to special logs so you can redirect that o
 
 ## What Properties exist
 
-The Properties list is available by looking at the javadoc for the `transport/src/main/java/org.ga4gh/ctk/config/Props.java` class. 
+The Properties list is available by looking at the javadoc for the `ctk-testrunner/src/main/java/org/ga4gh/ctk/config/Props.java` class. 
 
-> **NOTE**: The target server endpoints are controlled by a class `transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java` which loads the target server URL from the `ctk.tgt.urlRoot` property, which is set in the `transport/src/main/resources/defaulttransport.properties` file and can be overridden by replacing the properties file or with an external config element like an environment variable or on a command line.
+> **NOTE**: The target server endpoints are controlled by a class `ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java` which loads the target server URL from the `ctk.tgt.urlRoot` property, which is set in the `ctk-transport/src/main/resources/defaulttransport.properties` file and can be overridden by replacing the properties file or with an external config element like an environment variable or on a command line.
 
 ### Debugging URLMAPPER Initialization
 
@@ -77,7 +77,7 @@ Edit the properties file, and leave it in the launch directory or put it in a `c
 ## How a property is accessed
 
 Most properties are read in at launch and used to set fields on the Java object at
-`transport/src/main/java/org.ga4gh/ctk/config/Props.java` and this Props object is then used as
+`ctk-testrunner/src/main/java/org/ga4gh/ctk/config/Props.java` and this Props object is then used as
 the runtime source of property values. The Props object has a field (with a setter) for each property,
 and these fields are set by the Spring framework's @Value annotation; e.g. the property named
 "`ctk.testpackage`" is injected as:

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -7,6 +7,7 @@ Not all dependencies can be eliminated. This quickstart guide assumes that you h
 * [JDK 1.8 (aka J2SE 8)](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html)
 * [Maven](https://maven.apache.org) (version 3.2.5 or newer)
 * [git](https://git-scm.com)
+* `unzip` or similar zip decompressor
 
 All CLI commands are displayed in POSIX style (as tested on my MacOSX laptop). Translate as necessary when running on a Windows platform.
 
@@ -30,12 +31,12 @@ _In the compliance base directory_, run Maven to build the project:
 
 Before running any tests, you may want to set an environment variable to record the server URL you’re testing against:
 
-     > export CTK_TGT_URLROOT=“<your GA4GH-compatible server URL>"
+     > export CTK_TGT_URLROOT="<your GA4GH-compatible server URL>"
 
 You may also wish to set the dataset ID for the test dataset as an environment variable. Note that the ID given below is specific to the GA4GH reference server running on the compliance dataset, and will likely be different on another
 server implementation.
 
-     > export CTK_TGT_DATASET_ID=“YnJjYTE="
+     > export CTK_TGT_DATASET_ID="YnJjYTE="
 
 It is also possible to set these parameters on a per-run basis.
 

--- a/docs/StructureAndRationale.md
+++ b/docs/StructureAndRationale.md
@@ -49,7 +49,7 @@ avro    |              |     |                      |       |               |
 - **ctk-transport** is the JSON/HTTP/Avro connection module
 - **ctk-cli** is the command-line runner 
 - **cts-java** is the tests of the server (all in the src/test tree, treated as integration tests)
-- **cts-demo--java** is a module of examples test techniques (using the custom asserts, etc)
+- **cts-demo-java** is a module of examples test techniques (using the custom asserts, etc)
 - **dist** is a Maven assembly module, to build the distributions of the CTK (22 June 2015
 builds a single ZIP which unpacks to be the command-line tool)
 


### PR DESCRIPTION
Fixed smartquotes in code blocks in Quickstart.md
Added unzip to quickstart requirements to Quickstart.md
Fixed unmatched curly brace in Parameters annotation in ArchitectureOverview.md
Fixed a number of paths and clarified which .properties need editing in ConfigTheCTK.md
extra hyphen in 'cts-demo-java' in StructureAndRationale.md