### PR TITLE
Utils.getValidReferenceId no longer assumes a single reference set or reference

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
@@ -117,7 +117,10 @@ public class Utils {
      * @throws AvroRemoteException is the server throws an exception or there's an I/O error
      */
     public static String getValidReferenceId(Client client) throws AvroRemoteException {
-        final SearchReferenceSetsRequest refSetsReq = SearchReferenceSetsRequest.newBuilder().build();
+        final SearchReferenceSetsRequest refSetsReq =
+                SearchReferenceSetsRequest.newBuilder()
+                                          .setAssemblyId(TestData.REFERENCESET_ASSEMBLY_ID)
+                                          .build();
         final SearchReferenceSetsResponse refSetsResp = client.references.searchReferenceSets(refSetsReq);
 
         final List<ReferenceSet> refSets = refSetsResp.getReferenceSets();
@@ -125,6 +128,7 @@ public class Utils {
         final SearchReferencesRequest refsReq = SearchReferencesRequest
                 .newBuilder()
                 .setReferenceSetId(refSets.get(0).getId())
+                .setMd5checksums(aSingle(TestData.REFERENCE_BRCA1_MD5_CHECKSUM))
                 .build();
         final SearchReferencesResponse refsResp = client.references.searchReferences(refsReq);
         assertThat(refsResp).isNotNull();

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsPagingIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsPagingIT.java
@@ -138,8 +138,6 @@ public class ReadGroupSetsPagingIT {
     @Test
     public void checkTwoSimultaneousPagingSequencesThroughReadGroupSets() throws AvroRemoteException {
 
-        final String referenceId = Utils.getValidReferenceId(client);
-
         final Set<ReadGroupSet> setOfReadGroupSets0 = new HashSet<>();
         final Set<ReadGroupSet> setOfReadGroupSets1 = new HashSet<>();
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
@@ -84,7 +84,7 @@ public class ReadsSearchIT implements CtkLogs {
 
         final SearchReadsRequest srReq =
                 SearchReadsRequest.newBuilder()
-                                  .setReferenceId(Utils.getValidReferenceId(client))
+                                  .setReferenceId(refId)
                                   .setReadGroupIds(aSingle(Utils.getReadGroupId(client)))
                                   .setStart(start)
                                   .setEnd(end)


### PR DESCRIPTION
`Utils.getValidReferenceId` no longer assumes a single reference set or reference, but rather uses the IDs/names provided in `TestData` to look them up.

Removed unnecessary calls to it from `ReadGroupSetsPagingIT.checkTwoSimultaneousPagingSequencesThroughReadGroupSets` and `ReadsSearchIT.searchReadsProducesWellFormedReads`.

Fix for #117.