### PR TITLE
Remove unecessary getReferenceId calls and check that reference set lists are length 1

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/Utils.java
@@ -117,20 +117,16 @@ public class Utils {
      * @throws AvroRemoteException is the server throws an exception or there's an I/O error
      */
     public static String getValidReferenceId(Client client) throws AvroRemoteException {
-        final SearchReferenceSetsRequest refSetsReq = SearchReferenceSetsRequest.newBuilder().build();
-        final SearchReferenceSetsResponse refSetsResp = client.references.searchReferenceSets(refSetsReq);
-
-        final List<ReferenceSet> refSets = refSetsResp.getReferenceSets();
-
         final SearchReferencesRequest refsReq = SearchReferencesRequest
                 .newBuilder()
-                .setReferenceSetId(refSets.get(0).getId())
+                .setReferenceSetId(Utils.getReferenceSetIdByAssemblyId(client, TestData.REFERENCESET_ASSEMBLY_ID))
+                .setMd5checksum(TestData.REFERENCE_BRCA1_MD5_CHECKSUM)
                 .build();
         final SearchReferencesResponse refsResp = client.references.searchReferences(refsReq);
         assertThat(refsResp).isNotNull();
         final List<Reference> references = refsResp.getReferences();
         assertThat(references).isNotNull().isNotEmpty();
-
+        assertThat(references).hasSize(1);
         return references.get(0).getId();
     }
 
@@ -268,6 +264,7 @@ public class Utils {
                 client.references.searchReferenceSets(req);
         final List<ReferenceSet> refSets = resp.getReferenceSets();
         assertThat(refSets).isNotNull();
+        assertThat(refSets).hasSize(1);
         final ReferenceSet refSet = refSets.get(0);
         return refSet.getId();
     }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsPagingIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadGroupSetsPagingIT.java
@@ -138,8 +138,6 @@ public class ReadGroupSetsPagingIT {
     @Test
     public void checkTwoSimultaneousPagingSequencesThroughReadGroupSets() throws AvroRemoteException {
 
-        final String referenceId = Utils.getValidReferenceId(client);
-
         final Set<ReadGroupSet> setOfReadGroupSets0 = new HashSet<>();
         final Set<ReadGroupSet> setOfReadGroupSets1 = new HashSet<>();
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/reads/ReadsSearchIT.java
@@ -40,6 +40,8 @@ public class ReadsSearchIT implements CtkLogs {
     @Test
     public void searchReadsWithUninterestingRangeProducesZeroReads() throws AvroRemoteException {
 
+        final String refId = Utils.getValidReferenceId(client);
+
         final long emptyRangeStart = 150;
         final long emptyRangeEnd = 160;
 
@@ -53,7 +55,7 @@ public class ReadsSearchIT implements CtkLogs {
 
         final SearchReadsRequest srReq =
                 SearchReadsRequest.newBuilder()
-                                  .setReferenceId(Utils.getValidReferenceId(client))
+                                  .setReferenceId(refId)
                                   .setReadGroupIds(aSingle(Utils.getReadGroupId(client)))
                                   .setStart(emptyRangeStart)
                                   .setEnd(emptyRangeEnd)
@@ -84,7 +86,7 @@ public class ReadsSearchIT implements CtkLogs {
 
         final SearchReadsRequest srReq =
                 SearchReadsRequest.newBuilder()
-                                  .setReferenceId(Utils.getValidReferenceId(client))
+                                  .setReferenceId(refId)
                                   .setReadGroupIds(aSingle(Utils.getReadGroupId(client)))
                                   .setStart(start)
                                   .setEnd(end)


### PR DESCRIPTION
Fix #117 by reproducing Herb's changes on PR #128. Sets the checksum for a SearchReferenceRequest, removes unecessary calls to getReferenceId, and tests to ensure the length of the reference set arrays are equal to 1.