### PR TITLE
Changed internal version from 0.5.1-SNAPSHOT to 0.6.0a1

### DIFF
--- a/ctk-cli/pom.xml
+++ b/ctk-cli/pom.xml
@@ -23,13 +23,13 @@
     <description>CLI app to drive tests of GA4GH data server v0.5.1</description>
 
     <artifactId>ctk-cli</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0a1</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.ga4gh</groupId>
         <artifactId>ctk-parent</artifactId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent</relativePath>
     </parent>
     <!--
@@ -169,12 +169,12 @@
         <dependency> <!-- also provides ga4gh schema we run against -->
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-testrunner</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
 
     </dependencies>

--- a/ctk-cli/src/main/resources/application.properties
+++ b/ctk-cli/src/main/resources/application.properties
@@ -31,7 +31,7 @@ ctk.antfile=lib/antRunTests.xml
 # which is already in "./lib"
 # when run from command line (doesn't currently affect output when running maven)
 # THIS IS A HACK FOR ANT, we should be scanning the lib dir (soon)
-ctk.testjar=cts-java-0.5.1-SNAPSHOT-tests.jar
+ctk.testjar=cts-java-0.6.0a1-tests.jar
 
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)

--- a/ctk-cli/src/main/resources/ctk
+++ b/ctk-cli/src/main/resources/ctk
@@ -49,7 +49,7 @@ CMD_DIR="$(cd "$(dirname "$CMD")" && pwd -P)"
 # Defaults and command line options
 [ "$VERBOSE" ] ||  VERBOSE=
 [ "$DEBUG" ]   ||  DEBUG=
-[ "$CTKJAR" ]  ||  CTKJAR="ctk-cli-0.5.1-SNAPSHOT.jar"
+[ "$CTKJAR" ]  ||  CTKJAR="ctk-cli-0.6.0a1.jar"
 [ "$TGTDIR" ] || TGTDIR="target"
 
 

--- a/ctk-domain/pom.xml
+++ b/ctk-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ctk-schemas/pom.xml
+++ b/ctk-schemas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ctk-server/pom.xml
+++ b/ctk-server/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk-server</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0a1</version>
     <packaging>jar</packaging>
 
     <name>CTK Web Server</name>
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
 
-        <ga4gh.schema.local.version>0.5.1-SNAPSHOT</ga4gh.schema.local.version>
+        <ga4gh.schema.local.version>0.6.0a1</ga4gh.schema.local.version>
         <ctk.tgt.urlRoot>http://localhost:8000</ctk.tgt.urlRoot>
 
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -83,22 +83,22 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-testrunner</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-schemas</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/ctk-server/src/main/resources/application.properties
+++ b/ctk-server/src/main/resources/application.properties
@@ -31,7 +31,7 @@ ctk.antfile=lib/antRunTests.xml
 # which is already in "./lib"
 # when run from command line (doesn't currently affect output when running maven)
 # THIS IS A HACK FOR ANT, we should be scanning the lib dir (soon)
-ctk.testjar=cts-java-0.5.1-SNAPSHOT-tests.jar
+ctk.testjar=cts-java-0.6.0a1-tests.jar
 
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)

--- a/ctk-server/src/main/resources/ctk
+++ b/ctk-server/src/main/resources/ctk
@@ -49,7 +49,7 @@ CMD_DIR="$(cd "$(dirname "$CMD")" && pwd -P)"
 # Defaults and command line options
 [ "$VERBOSE" ] ||  VERBOSE=
 [ "$DEBUG" ]   ||  DEBUG=
-[ "$CTKJAR" ]  ||  CTKJAR="ctk-server-0.5.1-SNAPSHOT.jar"
+[ "$CTKJAR" ]  ||  CTKJAR="ctk-server-0.6.0a1.jar"
 [ "$TGTDIR" ] || TGTDIR="target"
 
 

--- a/ctk-testrunner/pom.xml
+++ b/ctk-testrunner/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk-testrunner</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0a1</version>
     <name>CTK Test Runner</name>
     <description>Test-running module (not self-executable, requires a launcher)</description>
     <parent>
         <groupId>org.ga4gh</groupId>
         <artifactId>ctk-parent</artifactId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent</relativePath>
     </parent>
 
@@ -113,7 +113,7 @@
         <dependency> <!-- also provides ga4gh schema we run against -->
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <!-- lombok saves us some typing in the COnfig class -->
         <dependency>

--- a/ctk-testrunner/src/main/resources/application.properties
+++ b/ctk-testrunner/src/main/resources/application.properties
@@ -31,7 +31,7 @@ ctk.antfile=lib/antRunTests.xml
 # which is already in "./lib"
 # when run from command line (doesn't currently affect output when running maven)
 # THIS IS A HACK FOR ANT, we should be scanning the lib dir (soon)
-ctk.testjar=cts-java-0.5.1-SNAPSHOT-tests.jar
+ctk.testjar=cts-java-0.6.0a1-tests.jar
 
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)

--- a/ctk-transport/pom.xml
+++ b/ctk-transport/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ga4gh</groupId>
         <artifactId>ctk-parent</artifactId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
 
         <!-- do we want to put slf4j-log4j12.jar on the path? or is OK it's supplied at runtime?-->

--- a/cts-demo-java/pom.xml
+++ b/cts-demo-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -16,17 +16,17 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-cli</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <!-- need BCEL during site build -->
         <dependency>

--- a/cts-java/pom.xml
+++ b/cts-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -26,12 +26,12 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-cli</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-server</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>cts-java</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0a1</version>
             <classifier>tests</classifier>
         </dependency>
     </dependencies>

--- a/docs/ConfigTheCTK.md
+++ b/docs/ConfigTheCTK.md
@@ -16,7 +16,7 @@ You can configure the CTK via the properties used by the:
 If you're working with CTK/CTS source (in an IDE or for a Maven build) it's easiest to just edit `ctk-cli/src/main/resources/application.properties`, `ctk-server/src/main/resources/application.properties`, and `ctk-testrunner/src/main/resources/application.properties`, but these changes will have no effect until you rebuild (because the rebuild copies the files from `src/main/resources/` into `target/` which is where the code runs from). But, you can make temporary changes to the text properties files directly in the output build `target` tree.
 
 If you're working with the CTK/CTS at the command line, you can extract that file from the packaged jar file and have it in the dir where the jar runs from
-(`jar xvf ctk-cli-v.0.5.1-SNAPSHOT.jar application.properties`) ... if you're using the ZIP distribution, it will already have extracted that properties file (and other control files) for you.
+(`jar xvf ctk-cli-v.0.6.0a1.jar application.properties`) ... if you're using the ZIP distribution, it will already have extracted that properties file (and other control files) for you.
 
 Note that individual test suites (`cts-java` etc) might have individual configuration mechanisms or properties files - refer to their documentation.
 
@@ -41,7 +41,7 @@ The Properties list is available by looking at the javadoc for the `ctk-testrunn
 
 Because URLMAPPING initialization is a static action which might happen without logs being available, the URLMAPPING class has a special Java system property property to cause it to dump all the static initialization actions directly to stdout:
 
-`java -Dctk.tgt.urlmapper.dump=true -jar ctk-cli-0.5.1-SNAPSHOT.jar`
+`java -Dctk.tgt.urlmapper.dump=true -jar ctk-cli-0.6.0a1.jar`
 
 Note that many tests reinitialize the URLMAPPER in a @BeforeClass, so you may see the initialization get dumped multiple times!
 
@@ -70,7 +70,7 @@ To set properties as a command line variable (the highest priority) for a Maven 
 ### Configuring a Command Line invocation
 From the directory where the executable jar is, you can edit `application.properties`. The zip distribution has this file pre-extracted, but if you don't already have it, just extract it from the executable jar like this
 
-    jar xvf ctk-cli-0.5.1-SNAPSHOT.jar application.properties
+    jar xvf ctk-cli-0.6.0a1.jar application.properties
 
 Edit the properties file, and leave it in the launch directory or put it in a `config` subdirectory.
 

--- a/docs/README-Server.txt
+++ b/docs/README-Server.txt
@@ -1,14 +1,14 @@
 This is an experimental web-server wrapper for the GA4GH Conformance Test Kit (CTK).
 
 Run it using the included 'ctk' script, or simply as
-    java -jar ctk-server-0.5.1-SNAPSHOT.jar
+    java -jar ctk-server-0.6.0a1.jar
 
 Once it is running, it exposes a server at port 8080. (Being a Spring Boot app,
 you can modify the port number with the normal --server.port= ... setting, like this:
 
    ./ctk --server.port=8088
    or
-   java -jar ctk-server-0.5.1-SNAPSHOT.jar --server.port=8088
+   java -jar ctk-server-0.6.0a1.jar --server.port=8088
 
 To run the tests, you just browse to that server using a web browser; it
 will run using the defaults and values set in the application properties file.

--- a/docs/RunningTests_CLI.md
+++ b/docs/RunningTests_CLI.md
@@ -4,11 +4,11 @@ The unzipped `dist/target/ga4gh-ctk-cli.zip` results in the following
 directory structure:
 
     <test_directory>/
-      | - ctk-cli-0.5.1-SNAPSHOT.jar
+      | - ctk-cli-0.6.0a1.jar
       | - application.properties
       | - ctk
       | - lib/
-      |       |- cts-java-0.5.1-SNAPSHOT-tests.jar
+      |       |- cts-java-0.6.0a1-tests.jar
       |       |- log4j2.xml
       |       |- antRunTests.xml
       | - target/
@@ -44,11 +44,11 @@ as in the next section.
 
 ### To use `java` to run the tests:
 
-    java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.tgt.urlRoot=<your server URL base>
+    java -jar ctk-cli-0.6.0a1.jar --ctk.tgt.urlRoot=<your server URL base>
 
 so, for example,
 
-    java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.tgt.urlRoot=http://myserver:8000
+    java -jar ctk-cli-0.6.0a1.jar --ctk.tgt.urlRoot=http://myserver:8000
 
 #### Tips
 
@@ -62,7 +62,7 @@ We'll assume you've done this and omit the `ctk.tgt.urlRoot` property from the e
 
 If you want to see a example of a test failing, add another property to your `java` command:
 
-    java -jar ctk-cli-0.5.1-SNAPSHOT.jar --cts.demofail=true
+    java -jar ctk-cli-0.6.0a1.jar --cts.demofail=true
 
 There will be some console output, and you can check in `testresults/<server_port>/<run #>/` for details;
 if you have a browser, open `testresults/<server_port>/<run #>/report/html/index.html`.
@@ -70,7 +70,7 @@ if you have a browser, open `testresults/<server_port>/<run #>/report/html/index
 If you want to attach a debugger to the command-line CTK, use:
 
     java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n \
-         -jar ctk-cli-0.5.1-SNAPSHOT.jar
+         -jar ctk-cli-0.6.0a1.jar
 
 For help on using the `java` command, refer to your Java vendor's documentation or the help provided with your installation (e.g., `man java` or `java -h`).
 
@@ -96,7 +96,7 @@ If you want to alter which tests get run, you can do that on the command line
 
 ```
 
-    $ java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.matchstr=.*ReadMethodsEndpointAliveIT.*
+    $ java -jar ctk-cli-0.6.0a1.jar --ctk.matchstr=.*ReadMethodsEndpointAliveIT.*
     [TESTLOG] 4 failed, 6 passed, 0 skipped, 1068 ms
     [TESTLOG] FAIL: [0] TWO_GOOD, NOT_IMPLEMENTED (multipleReadGroupsNotSupported)(org.ga4gh.cts.api.reads.ReadMethodsEndpointAliveIT):
     ...
@@ -135,7 +135,7 @@ The other two classes are for a near-future capability that isn't quite ready fo
 
 To run a selected test, we just match its name as an Ant-style regex to the `ctk.matchstr` property:
 
-` java -jar ctk-cli-0.5.1-SNAPSHOT.jar --ctk.matchstr=**/*ReadMethods.class`
+` java -jar ctk-cli-0.6.0a1.jar --ctk.matchstr=**/*ReadMethods.class`
 
  or
 
@@ -176,7 +176,7 @@ This test just passes or fails based on a property; here's the example code:
 We'll compile and package it (not shown).  Then let's run it:
 
 ```
-$ java -jar ctk-cli-0.5.1-SNAPSHOT.jar --cts.demofail=true --ctk.matchstr=**/*Landing*.class
+$ java -jar ctk-cli-0.6.0a1.jar --cts.demofail=true --ctk.matchstr=**/*Landing*.class
 [TESTLOG] Suite start org.ga4gh.cts.api.datasets.DatasetsPagingIT
 [TESTLOG] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.474 sec
 [TESTLOG] Suite start org.ga4gh.cts.api.datasets.DatasetsSearchIT

--- a/docs/RunningTests_maven.md
+++ b/docs/RunningTests_maven.md
@@ -122,7 +122,7 @@ processes):
     2. edit `application-properties` (or set environment properties) to point to the in-source location of files, for example:
         1. `ctk.antfile=../ctk-testrunner/src/main/resources/antRunTests.xml`
         2. `ctk.defaulttransportfile=../ctk-transport/src/main/resources/defaulttransport.properties/defaulttransport.properties`
-        3. `ctk.testjar=../cts-java/target/cts-java-0.5.1-SNAPSHOT-tests.jar`
+        3. `ctk.testjar=../cts-java/target/cts-java-0.6.0a1-tests.jar`
         4. `ctk.testclassroots=../cts-java/target/test-classes`
         5. `ctk.domaintypesfile=../ctk-domain/src/main/resources/avro-types.json`
     2. manually create a `ctk-cli/lib` directory and copy into it the logging control file(s) from

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk-parent</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0a1</version>
 
     <packaging>pom</packaging>
 
@@ -29,7 +29,7 @@
 
 
     <properties>
-        <ga4gh.schema.local.version>0.5.1-SNAPSHOT</ga4gh.schema.local.version>
+        <ga4gh.schema.local.version>0.6.0a1</ga4gh.schema.local.version>
         <ctk.tgt.urlRoot>http://localhost:8000</ctk.tgt.urlRoot>
         <!-- Controls skipping of cts-java IT tests during build; skip the tests by passing
              a command line parameter, e.g. mvn -Dcts.skipITs=true install.  Run them by default. -->

--- a/pom.xml
+++ b/pom.xml
@@ -36,13 +36,13 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.5.1-SNAPSHOT</version>
+        <version>0.6.0a1</version>
         <relativePath>parent</relativePath>
     </parent>
 
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk</artifactId>
-<!--    <version>0.5.1-SNAPSHOT</version>-->
+<!--    <version>0.6.0a1</version>-->
     <packaging>pom</packaging>
 
     <organization>


### PR DESCRIPTION
I should have caught this one before. The compliance suite was using the `0.5.1-SNAPSHOT` name internally all over the place. Please take a quick look and +1 so we can release this ASAP.