### PR TITLE
sync schemas - use approved metadata records & correct feature search key

### DIFF
--- a/ctk-schemas/src/main/resources/avro/alleleAnnotationmethods.avdl
+++ b/ctk-schemas/src/main/resources/avro/alleleAnnotationmethods.avdl
@@ -76,7 +76,7 @@ record SearchVariantAnnotationsRequest {
   must be supplied.
   If null, return all variant annotations in specified window.
   */
-  union { null, array<string> } feature_ids = null;
+  union { null, array<string> } featureIds = null;
 
   /**
   Only return variant annotations including these effects (SO terms).

--- a/ctk-schemas/src/main/resources/avro/metadata.avdl
+++ b/ctk-schemas/src/main/resources/avro/metadata.avdl
@@ -14,24 +14,19 @@ import idl "common.avdl";
   */
   record OntologyTerm {
     /**
-    ontology source name - the name of ontology from which the term is obtained
-    e.g. 'Human Phenotype Ontology'
+    The source of the onotology term.
+    (e.g. `Ontology for Biomedical Investigation`)
     */
-    union { null, string } ontologySourceName = null;
+    string ontologySource;
 
     /**
-    ontology source identifier - the identifier, a CURIE (preferred) or
-    PURL for an ontology source e.g. http://purl.obolibrary.org/obo/hp.obo
+    The ID defined by the external onotology source.
+    (e.g. `http://purl.obolibrary.org/obo/OBI_0001271`)
     */
-    union { null, string } ontologySourceID = null;
+    string id;
 
-    /**
-    ontology source version - the version of the ontology from which the
-    OntologyTerm is obtained; e.g. 2.6.1.
-    There is no standard for ontology versioning and some frequently
-    released ontologies may use a datestamp, or build number.
-    */
-    union { null, string } ontologySourceVersion = null;
+    /** The name of the onotology term. (e.g. `RNA-seq assay`) */
+    union { null, string } name = null;
   }
 
 /**
@@ -116,51 +111,6 @@ record Experiment {
   */
   map<array<string>> info = {};
 }
-/**
-  An analysis contains an interpretation of one or several experiments.
-  (e.g. SNVs, copy number variations, methylation status) together with
-  information about the methodology used.
-  TODO: review
-  */
-  record Analysis {
-
-    /**
-    Formats of id | guid | name | description | accessions are described in the
-    documentation on general attributes and formats.
-    */
-    string id;
-
-    union { null, string } guid = null;
-
-    union { null, string } name = null;
-
-    union { null, string } description = null;
-
-    array<string> accessions;
-
-    /**
-    The times at which this record was created / updated.
-    Format: ISO 8601 (cf. documentation on time formats)
-    */
-    string recordCreateTime;
-    string recordUpdateTime;
-
-    /**
-    The type of analysis.
-    */
-    union { null, string } type = null;
-
-    /**
-    The software run to generate this analysis.
-    */
-    array<string> software = [];
-
-    /**
-    A map of additional information.
-    */
-    map<array<string>> info = {};
-
-  }
 
 /**
 A Dataset is a collection of related data of multiple types.
@@ -185,4 +135,42 @@ record Dataset {
 
 }
 
+/**
+An analysis contains an interpretation of one or several experiments.
+(e.g. SNVs, copy number variations, methylation status) together with
+information about the methodology used.
+*/
+record Analysis {
+  /** The analysis UUID. This is globally unique. */
+  string id;
+
+  /** The name of the analysis. */
+  union { null, string } name = null;
+
+  /** A description of the analysis. */
+  union { null, string } description = null;
+
+  /**
+  The time at which this record was created. 
+  Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
+  */
+  union { null, string } recordCreateTime = null;
+
+  /**
+  The time at which this record was last updated.
+  Format: ISO 8601, YYYY-MM-DDTHH:MM:SS.SSS (e.g. 2015-02-10T00:03:42.123Z)
+  */
+  string recordUpdateTime;
+
+  /** The type of analysis. */
+  union { null, string } type = null;
+
+  /** The software run to generate this analysis. */
+  array<string> software = [];
+
+  /**
+  A map of additional analysis information.
+  */
+  map<array<string>> info = {};
+}
 }


### PR DESCRIPTION
Hi @david4096

This updates the compliance schemas to those used by the schema & server repos.

I'm sending it as a PR so you can see the changes and merge when convenient. The main difference is the metadata fix, which should not have any impact on the tests.
In addition, SearchVariantAnnotationsRequest has had feature_ids renamed to featureIds to match the standard naming convention. The reference server and ensembl server have been updated for this change, so the compliance test filtering on feature id will fail until this PR is merged.