### PR TITLE
Changed ctk-domain pom.xml to delete generated assertions fix #152

### DIFF
--- a/ctk-domain/pom.xml
+++ b/ctk-domain/pom.xml
@@ -55,6 +55,18 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                <filesets>
+                    <fileset>
+                        <directory>src/main/assertj-assertions</directory>
+                        <followSymlinks>false</followSymlinks>
+                    </fileset>
+                </filesets>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>1.9.1</version>


### PR DESCRIPTION
When switching back and forth from branches with different schema the list of assertion files to generate wasn't being deleted. Now it is, so you can `mvn clean` between schema changes without an issue.