### PR TITLE
Added a test for finding variant annotation sets by their ID. fixed #144

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/variantAnnotation/VariantAnnotationSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variantAnnotation/VariantAnnotationSetsSearchIT.java
@@ -56,4 +56,21 @@ public class VariantAnnotationSetsSearchIT implements CtkLogs {
                              .forEach(vas -> assertThat(vas.getVariantSetId()).isNotNull());
 
     }
+
+    /**
+     * Check to see if variant annotation sets can be gotten by their ID.
+     *
+     *@throws AvroRemoteException if there's a communication problem or server exception ({@link GAException})
+     */
+    @Test
+    public void checkGetVariantAnnotationSetById() throws AvroRemoteException {
+        // Find a variant annotation set ID using search
+        final String variantAnnotationSetId = Utils.getVariantAnnotationSetId(client);
+
+        // Get a variant annotation set using GET
+        final VariantAnnotationSet vSet = client.variantAnnotations.getVariantAnnotationSet(variantAnnotationSetId);
+
+        assertThat(vSet).isNotNull();
+        assertThat(vSet.getId()).isEqualTo(variantAnnotationSetId);
+    }
 }


### PR DESCRIPTION
Ref server is currently failing this test without the GET endpoint implemented.