### PR TITLE
Check that Variant in the VariantAnnotation record exists 

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantSetsSearchIT.java
@@ -52,7 +52,7 @@ public class VariantSetsSearchIT implements CtkLogs {
      */
     @Test
     public void checkExpectedVariantSets() throws AvroRemoteException {
-        final int expectedNumberOfVariantSets = 1;
+        final int expectedNumberOfVariantSets = 2;
 
         final SearchVariantSetsRequest req =
                 SearchVariantSetsRequest.newBuilder()


### PR DESCRIPTION
This requires a second VariantSet, so VariantSetsSearchIT is also updated - it is a more useful check to page through more than one record.