### PR TITLE
Brings g2p in with latest schemas and add test data file

### DIFF
--- a/ctk-schemas/src/main/resources/avro/genotypephenotype.avdl
+++ b/ctk-schemas/src/main/resources/avro/genotypephenotype.avdl
@@ -1,0 +1,176 @@
+@namespace("org.ga4gh.models")
+/**
+
+This protocol defines the associations between genotype
+and phenotype (G2P).  Associations can be made as a
+result of literature curation, computational modeling,
+inference, etc., and modeled and shared using this schema.
+
+Here, we follow the dogma of:
+
+      Genotype + Environment = Phenotype
+
+where a G2P association is between the G(enotype) in the context of
+some E(environment), which gives rise to a P(henotype). These
+associations have further evidence, provenance, and attribution.
+
+We leverage the GenomicFeature in the sequenceAnnotation schema here
+as it can accomodate any genomic feature from a single nucleotide variation
+(SNV), up through a gene, and/or complex rearrangements.  Each can
+be modeled as genomic features, and generally linked to a phenotype.
+Collections of these features can represent a genotype at different levels
+of completeness.  Therefore, we can represent single allelic variation,
+allelic complement, and multiple variants in a genotype that can each or
+collectively be associated with a phenotype.
+
+To enable standardized integration, this schema relies heavily on
+OntologyTerms, for typing phenotype, genomic features, and levels
+of evidence.  Suggested ontologies to leverage include (with browser links):
+Human Phenotype Ontology (HPO): http://www.ontobee.org/browser/index.php?o=hp
+Disease Ontology (DO): http://purl.obolibrary.org/obo/DOID_4
+Sequence Ontology (SO): http://www.sequenceontology.org/browser/
+Evidence Code Ontology (ECO): http://www.ontobee.org/browser/index.php?o=ECO
+Phenotypic Qualities (PATO): http://www.ontobee.org/browser/index.php?o=PATO
+*/
+protocol GenotypePhenotype {
+
+import idl "common.avdl";
+import idl "metadata.avdl";
+import idl "sequenceAnnotations.avdl";
+
+
+/**
+The context in which a genotype gives rise to a phenotype.
+This is fairly open-ended; as a stub we have a simple ontology term.
+For example, a controlled term for a drug, or perhaps an instance of a 
+complex environment including temperature and air quality, or perhaps
+the anatomical environment (gut vs tissue type vs whole organism).
+*/
+record EnvironmentalContext {
+
+  /** The Environment ID. */
+  union { null, string } id = null;
+
+  /**
+  Examples of some environment types could be drawn from:
+  Ontology for Biomedical Investigations (OBI): http://purl.obofoundry.org/obo/obi/browse
+  Chemical Entities of Interest (ChEBI): http://www.ontobee.org/browser/index.php?o=chebi
+  Environment Ontology (ENVO):  http://www.ontobee.org/browser/index.php?o=ENVO
+  Anatomy (Uberon): http://www.ontobee.org/browser/index.php?o=uberon
+  */
+  OntologyTerm environmentType;
+
+  /** 
+	A textual description of the environment. This is used to complement 
+	the structured description in the environmentType field 
+  */
+  union { null, string } description = null;
+
+}
+
+
+/**
+An association to a phenotype and related information.
+This record is intended primarily to be used in conjunction with variants, but 
+the record can also be composed with other kinds of entities such as diseases
+*/
+record PhenotypeInstance {
+  /** The Phenotype ID. */
+  union { null, string } id;
+
+  /** HPO is recommended */
+  OntologyTerm type;
+
+  /** 
+  PATO is recommended.  Often this qualifier might be for abnormal/normal, 
+  or severity.
+  For example, severe: http://purl.obolibrary.org/obo/PATO_0000396 
+  or abnormal: http://purl.obolibrary.org/obo/PATO_0000460
+  */
+  union { null, array<OntologyTerm> } qualifier = null;
+
+  //TODO: also allow quantitative recording?
+  /** 
+  HPO is recommended, for example, subclasses of
+  http://purl.obolibrary.org/obo/HP_0011007
+  */
+  union { null, OntologyTerm } ageOfOnset = null;
+
+  /** 
+  A textual description of the phenotype. This is used to complement the 
+  structured phenotype description in the type field. 
+  */
+  union { null, string } description = null;
+
+}
+
+
+/**
+Evidence for the phenotype association.
+This is also a stub for further expansion.  We should consider moving this into 
+it's own schema.
+*/
+record Evidence {
+
+  /** ECO or OBI is recommended */
+  OntologyTerm evidenceType;
+
+  /** 
+	A textual description of the evidence. This is used to complement the 
+	structured description in the evidenceType field 
+	*/
+  union { null, string } description = null;
+
+}
+
+/**
+An association between one or more genomic features and a phenotype.
+The instance of association allows us to link a feature to a phenotype,
+multiple times, each bearing potentially different levels of confidence,
+such as resulting from alternative experiments and analysis.
+*/
+record FeaturePhenotypeAssociation {
+  string id;
+
+  /**
+    The set of features of the organism that bears the phenotype.
+    This could be as complete as a full complement of variants,
+    or as minimal as the confirmed variants that are known causation
+    for the annotated phenotype.  
+    Examples of features could be variations at the nucleotide level, 
+    large rearrangements at the chromosome level, or relevant epigenetic
+    markers.  Relevant genomic feature types are suggested to be 
+    those typed in the Sequence Ontology (SO).
+
+    The feature set can have only one item, and must not be null.
+  */
+  array<Feature> features;
+
+ /**
+    The evidence for this specific instance of association between the
+    features and the phenotype.
+  */
+  array<Evidence> evidence;
+
+  /**
+    The phenotypic component of this association.
+    Note that we delegate this to a separate record to allow us the flexibility 
+	to composition of phenotype associations with records that are not 
+	variant sets - for example, diseases.
+  */
+  PhenotypeInstance phenotype;
+
+  /** A textual description of the association. */
+  union { null, string } description = null;
+
+  /**
+  The context in which the phenotype arises.
+  Multiple contexts can be specified - these are assumed to all hold together
+  */
+  array<EnvironmentalContext> environmentalContexts;
+
+}
+
+
+
+}

--- a/ctk-schemas/src/main/resources/avro/genotypephenotypemethods.avdl
+++ b/ctk-schemas/src/main/resources/avro/genotypephenotypemethods.avdl
@@ -1,0 +1,159 @@
+
+@namespace("org.ga4gh.methods")
+/**
+This protocol defines genotype to phenotype association
+query system.
+
+Suggested ontologies used in type-based queries include:
+
+Phenotype:
+Human Phenotype Ontology (HPO): http://www.ontobee.org/browser/index.php?o=hp
+Disease Ontology (DO): http://purl.obolibrary.org/obo/DOID_4
+
+Feature:
+Sequence Ontology (SO): http://www.sequenceontology.org/browser/
+
+Evidence:
+Evidence Code Ontology (ECO): http://www.ontobee.org/browser/index.php?o=ECO
+Ontology for Biomedical Investigations (OBI): http://purl.obofoundry.org/obo/obi/browse
+*/
+protocol GenotypePhenotypeMethods {
+
+
+import idl "genotypephenotype.avdl";
+import idl "methods.avdl";
+import idl "common.avdl";
+
+/******************  /genotypephenotype/search  *********************/
+
+
+
+/**
+Evidence for the phenotype association.
+*/
+record EvidenceQuery {
+  /** ECO or OBI is recommended */
+  array<org.ga4gh.models.OntologyTerm> evidenceType;
+}
+
+
+/**
+The feature collection to search for.  One or more features (variants,
+genes, etc) can be specified.  The idea here is that if a
+query is for a gene, then any alleles to that gene for which
+there are annotation records would be returned.
+*/
+record GenomicFeatureQuery {
+  array<org.ga4gh.models.Feature> features;
+}
+
+
+/**
+One or more phenotypes can be queried together.
+*/
+record PhenotypeQuery {
+  array<org.ga4gh.models.PhenotypeInstance> phenotypes;
+}
+
+/**
+One or more ontology terms can be queried together.
+*/
+record OntologyTermQuery {
+  array<org.ga4gh.models.OntologyTerm> terms;
+}
+
+/**
+One or more ids can be queried together.  Generally used for instances
+of a particular class of object (e.g. a specific gene or SNP).
+*/
+record ExternalIdentifierQuery {
+  array<org.ga4gh.models.ExternalIdentifier> ids;
+}
+
+/**
+This request maps to the body of `POST /genotypephenotype/search` as JSON.
+
+The goal here is to allow users to query using one or more of
+Genotype, Phenotype, Environment, and Evidence.
+
+A query using one of the above items is to mean, by default,
+that the remainder of the query is as a "wildcard", such
+that all matches to just that query term would come back.
+Combinations of the above are to act like AND rather than OR.
+
+The "genotype" part of the query methods can be one or more
+genomic features.  Associations can be made at many
+levels of granularity (from whole genotypes down to individual
+SNVs), but users may use these methods with partial or
+inexact information.  Therefore, the query methods must be
+able to support query of some or all of the associated features.
+Furthermore, use of the relationships between genomic features
+means that when querying for a gene, any variants to that
+gene are also returned.  For example, a query with
+BRCA2 would mean that in addition to any direct associations
+to the BRCA2, all associations to sequence variants of BRCA2 would also
+be returned.  Similarly, queries with OntologyTerms should perform
+the subclass closure.
+
+Each query can be made against a string, an array of external
+identifers (such as for gene or SNP ids), ontology term ids, or
+full feature/phenotype/evidence objects.
+*/
+record SearchGenotypePhenotypeRequest {
+
+  union {null, string, ExternalIdentifierQuery, OntologyTermQuery,
+         GenomicFeatureQuery} feature = null;
+
+  union {null, string, ExternalIdentifierQuery, OntologyTermQuery,
+         PhenotypeQuery} phenotype = null;
+
+  union {null, string, ExternalIdentifierQuery, OntologyTermQuery,
+         EvidenceQuery} evidence = null;
+
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+
+/** This is the response from `POST /genotypephenotype/search` expressed as JSON. */
+record SearchGenotypePhenotypeResponse {
+  /**
+  The list of matching FeaturePhenotypeAssociation.
+  */
+  array<org.ga4gh.models.FeaturePhenotypeAssociation> associations = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of evidence accessible through the API.
+
+`POST /genotypephenotype/search` must accept a JSON version of
+`SearchGenotypePhenotypeRequest` as the post body and will return a JSON version
+of `SearchGenotypePhenotypeResponse`.
+*/
+SearchGenotypePhenotypeResponse searchGenotypePhenotype(
+  /**
+  This request maps to the body of `POST /genotypepheotype/search` as JSON.
+  */
+  SearchGenotypePhenotypeRequest request) throws GAException;
+
+
+
+}

--- a/ctk-schemas/src/main/resources/avro/metadata.avdl
+++ b/ctk-schemas/src/main/resources/avro/metadata.avdl
@@ -9,7 +9,43 @@ protocol Metadata {
 import idl "common.avdl";
 
 /**
-An experimental preparation of a sample.
+  An ontology term describing an attribute. (e.g. the phenotype attribute
+  'polydactyly' from HPO)
+  */
+
+record OntologyTerm {
+  /**
+  Ontology source identifier - the identifier, a CURIE (preferred) or
+  PURL for an ontology source e.g. http://purl.obolibrary.org/obo/hp.obo
+  It differs from the standard GA4GH schema's :ref:`id <apidesign_object_ids>`
+  in that it is a URI pointing to an information resource outside of the scope
+  of the schema or its resource implementation.
+  */
+  string id;
+
+  /**
+  Ontology term - the representation the id is pointing to.
+  */
+  union { null, string } term = null;
+
+  /**
+  Ontology source name - the name of ontology from which the term is obtained
+  e.g. 'Human Phenotype Ontology'
+  */
+  union { null, string } sourceName = null;
+
+  /**
+  Ontology source version - the version of the ontology from which the
+  OntologyTerm is obtained; e.g. 2.6.1.
+  There is no standard for ontology versioning and some frequently
+  released ontologies may use a datestamp, or build number.
+  */
+  union { null, string } sourceVersion = null;
+}
+
+
+/**
+An experimental preparation of a `Sample`.
 */
 record Experiment {
   /** The experiment UUID. This is globally unique. */

--- a/ctk-schemas/src/main/resources/avro/references.avdl
+++ b/ctk-schemas/src/main/resources/avro/references.avdl
@@ -12,7 +12,7 @@ A `Reference` is a canonical assembled contig, intended to act as a
 reference coordinate space for other genomic annotations. A single
 `Reference` might represent the human chromosome 1, for instance.
 
-`Reference`s are designed to be immutable.
+`Reference's` are designed to be immutable.
 */
 record Reference {
 

--- a/ctk-schemas/src/main/resources/avro/sequenceAnnotations.avdl
+++ b/ctk-schemas/src/main/resources/avro/sequenceAnnotations.avdl
@@ -1,0 +1,137 @@
+@namespace("org.ga4gh.models")
+/**
+This protocol defines annotations on GA4GH genomic sequences It includes two
+types of annotations: continuous and discrete hierarchical.
+
+The discrete hierarchical annotations are derived from the Sequence Ontology
+(SO) and GFF3 work 
+
+   http://www.sequenceontology.org/gff3.shtml
+
+The goal is to be able to store annotations using the GFF3 and SO conceptual
+model, although there is not necessarly a one-to-one mapping in Avro records
+to GFF3 records.
+
+The minimum requirement is to be able to accurately represent the current
+state of the art annotation data and the full SO model.  Feature is the
+core generic record which corresponds to the a GFF3 record.
+*/
+protocol SequenceAnnotations {
+
+  import idl "common.avdl";
+  import idl "metadata.avdl";
+
+  /**
+  Type defining a collection of attributes associated with various protocol
+  records.  Each attribute is a name that maps to an array of one or more
+  values.  Values can be strings, external identifiers, or ontology terms.
+  Values should be split into the array elements instead of using a separator
+  syntax that needs to parsed.
+  */
+  // TODO: how are multiple instances of a given attribute vs multiple values
+  // for an attribute distinguished
+  record Attributes {
+    map<array<union {string, ExternalIdentifier, OntologyTerm}>> vals = {};
+  }
+  
+  /**
+  Node in the annotation graph that annotates a contiguous region of a
+  sequence.
+  */
+  record Feature {
+    /**
+    Id of this annotation node.
+    */
+    string id;
+
+    /**
+    Parent Id of this node. Set to empty string if node has no parent.
+    */
+    string parentId;
+
+    /**
+    Ordered array of Child Ids of this node.
+    Since not all child nodes are ordered by genomic coordinates,
+    this can't always be reconstructed from parentId's of the children alone.
+    */
+
+    array<string> childIds = [];
+
+    /**
+    Identifier for the containing feature set.
+    */
+    string featureSetId;
+
+    /**
+    The reference on which this feature occurs.
+    (e.g. `chr20` or `X`)
+    */
+    string referenceName;
+
+    /**
+    The start position at which this feature occurs (0-based).
+    This corresponds to the first base of the string of reference bases.
+    Genomic positions are non-negative integers less than reference length.
+    Features spanning the join of circular genomes are represented as
+    two features one on each side of the join (position 0).
+    */
+    long start = 0;
+
+    /**
+    The end position (exclusive), resulting in [start, end) closed-open interval.
+    This is typically calculated by `start + referenceBases.length`.
+    */
+    long end;
+
+    /**
+    The strand on which the feature is present.
+    */
+    Strand strand;
+
+    /**
+    Feature that is annotated by this region.  Normally, this will be a term in
+    the Sequence Ontology.
+    */
+    OntologyTerm featureType;
+
+    /**
+    Name/value attributes of the annotation.  Attribute names follow the GFF3
+    naming convention of reserved names starting with an upper cases
+    character, and user-define names start with lower-case.  Most GFF3
+    pre-defined attributes apply, the exceptions are ID and Parent, which are
+    defined as fields. Additional, the following attributes are added:
+    * Score - the GFF3 score column
+    * Phase - the GFF3 phase column for CDS features.
+    */
+    Attributes attributes;
+  }
+
+  /*
+  A set of sequence features annotations
+  */
+  record FeatureSet {
+    /** The ID of this annotation set. */
+    string id;
+
+    /** The ID of the dataset this annotation set belongs to. */
+   union { null, string } datasetId = null;
+
+    /**
+    The ID of the reference set which defines the coordinate-space for this
+    set of annotations.
+    */
+    union { null, string } referenceSetId;
+
+    /** The display name for this annotation set. */
+    union { null, string } name = null;
+
+    /**
+    The source URI describing the file from which this annotation set was
+    generated, if any.
+    */
+    union { null, string } sourceURI = null;
+
+    /** Remaining structured metadata key-value pairs. */
+    map<array<string>> info = {};
+  }
+}

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPING.java
@@ -39,6 +39,10 @@ public interface URLMAPPING {
 
     void setSearchReads(String searchReads);
 
+    String getSearchGenotypePhenotype();
+
+    void setSearchGenotypePhenotype(String searchGenotypePhenotype);
+
     String getSearchReadGroupSets();
 
     void setSearchReadGroupSets(String searchReadGroupSets);

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPINGImpl.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPINGImpl.java
@@ -60,6 +60,7 @@ public class URLMAPPINGImpl implements URLMAPPING {
         defaultEndpoints.put("ctk.tgt.searchVariantSets", "variantsets/search");
         defaultEndpoints.put("ctk.tgt.searchVariants", "variants/search");
         defaultEndpoints.put("ctk.tgt.searchCallsets", "callsets/search");
+        defaultEndpoints.put("ctk.tgt.searchGenotypePhenotype", "genotypephenotype/search");
         defaultEndpoints.put("ctk.tgt.getReferences", "references/{id}");
         defaultEndpoints.put("ctk.tgt.getReferencesets", "referencesets/{id}");
         defaultEndpoints.put("ctk.tgt.getReferencesBases", "references/{id}/bases");
@@ -70,6 +71,8 @@ public class URLMAPPINGImpl implements URLMAPPING {
         defaultEndpoints.put("ctk.tgt.getDataset", "datasets/{id}");
         defaultEndpoints.put("ctk.tgt.getVariant", "variants/{id}");
         defaultEndpoints.put("ctk.tgt.getVariantSet", "variantsets/{id}");
+        defaultEndpoints.put("ctk.tgt.getCallset", "callsets/{id}");
+        defaultEndpoints.put("ctk.tgt.getCallset", "callsets/{id}");
         defaultEndpoints.put("ctk.tgt.getCallset", "callsets/{id}");
 
         dumpToStdOut = Boolean.getBoolean("ctk.tgt.urlmapper.dump"); // so, -Dctk.tgt.urlmapper.dump=true
@@ -350,6 +353,15 @@ public class URLMAPPINGImpl implements URLMAPPING {
     @Override
     public void setSearchReferencesets(String searchReferencesets) {
         endpoints.put("ctk.tgt.searchReferencesets", searchReferencesets);
+    }
+    @Override
+    public String getSearchGenotypePhenotype() {
+        return endpoints.get("ctk.tgt.searchGenotypePhenotype");
+    }
+
+    @Override
+    public void setSearchGenotypePhenotype(String searchGenotypePhenotype) {
+        endpoints.put("ctk.tgt.searchGenotypePhenotype", searchGenotypePhenotype);
     }
 
     @Override

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
@@ -53,6 +53,14 @@ public class Client {
     public final References references = new References();
 
     /**
+     * Provides access to GenotypePhenotype-related methods.  For example,
+     * <pre>
+     *     myClient.genotypePhenotype(...); TODO document
+     * </pre>
+     */
+    public final GenotypePhenotype genotypePhenotype = new GenotypePhenotype();
+
+    /**
      * Provides access to metadata-related methods.  For example,
      * <pre>
      *     myClient.metadata.searchDatasets(...);
@@ -398,6 +406,24 @@ public class Client {
                 throws AvroRemoteException {
             wireTracker = wt;
             return searchReadGroupSets(request);
+        }
+    }
+
+    /**
+     * Inner class holding all GenotypePheotype-related methods.  Gathering them in an inner class like this
+     * makes it a little easier for someone writing tests to use their IDE's auto-complete
+     * to type method names.
+     */
+    public class GenotypePhenotype implements GenotypePhenotypeMethods {
+
+        @Override
+        public SearchGenotypePhenotypeResponse searchGenotypePhenotype(SearchGenotypePhenotypeRequest request) throws AvroRemoteException, GAException {
+            String path = urls.getSearchGenotypePhenotype();
+            SearchGenotypePhenotypeResponse response = new SearchGenotypePhenotypeResponse();
+            final AvroJson aj =
+                    new AvroJson<>(request, response, urls.getUrlRoot(), path, wireTracker);
+            response = (SearchGenotypePhenotypeResponse)aj.doPostResp();
+            return response;
         }
     }
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -148,5 +148,67 @@ public class TestData {
             return DEFAULT_DATASET_ID;
         }
     }
+    /**
+     * GenotypePhenotype PHENOTYPE external database name.
+     */
+    public static final String PHENOTYPE_DB = "http://ohsu.edu/cgd/";
 
+    /**
+     * GenotypePhenotype PHENOTYPE external database identifier.
+     */
+    public static final String PHENOTYPE_DB_ID = "37da8697";
+
+    /**
+     * GenotypePhenotype PHENOTYPE external database Version.
+     */
+    public static final String PHENOTYPE_DB_VERSION = "*";
+    /**
+     * GenotypePhenotype PHENOTYPE name.
+     */
+    public static final String PHENOTYPE_NAME =  "GIST";
+
+    /**
+     * GenotypePhenotype EVIDENCE external database name.
+     */
+    public static final String EVIDENCE_DB = "http://www.drugbank.ca/drugs/";
+
+    /**
+     * GenotypePhenotype EVIDENCE external database identifier.
+     */
+    public static final String EVIDENCE_DB_ID = "DB00619";
+
+    /**
+     * GenotypePhenotype EVIDENCE external database Version.
+     */
+    public static final String EVIDENCE_DB_VERSION = "*";
+
+    /**
+     * GenotypePhenotype EVIDENCE name.
+     */
+    public static final String EVIDENCE_NAME =  "imatinib";
+
+    /**
+     * GenotypePhenotype EVIDENCE LEVEL.
+     */
+    public static final String EVIDENCE_LEVEL = "early trials";
+
+    /**
+     * GenotypePhenotype FEATURE external database name.
+     */
+    public static final String FEATURE_DB = "http://ohsu.edu/cgd/";
+
+    /**
+     * GenotypePhenotype FEATURE external database identifier.
+     */
+    public static final String FEATURE_DB_ID = "4841bf74";
+
+    /**
+     * GenotypePhenotype FEATURE external database Version.
+     */
+    public static final String FEATURE_DB_VERSION = "*";
+
+    /**
+     * GenotypePhenotype FEATURE name.
+     */
+    public static final String FEATURE_NAME = "KIT *wild" ;
 }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/g2p/GenotypePhenotypeSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/g2p/GenotypePhenotypeSearchIT.java
@@ -1,0 +1,233 @@
+package org.ga4gh.cts.api.g2p;
+
+import org.apache.avro.AvroRemoteException;
+import org.ga4gh.ctk.transport.GAWrapperException;
+import org.ga4gh.ctk.transport.URLMAPPING;
+import org.ga4gh.ctk.transport.protocols.Client;
+import org.ga4gh.cts.api.TestData;
+import org.ga4gh.cts.api.Utils;
+import org.ga4gh.methods.ExternalIdentifierQuery;
+import org.ga4gh.methods.SearchGenotypePhenotypeRequest;
+import org.ga4gh.methods.SearchGenotypePhenotypeResponse;
+import org.ga4gh.models.ExternalIdentifier;
+import org.ga4gh.models.Evidence;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ga4gh.cts.api.Utils.catchGAWrapperException;
+
+/**
+ * Tests dealing with searching for GenotypePhenotype associations.
+ *
+ * @author Brian Walsh
+ */
+@Category(GenotypePhenotypeTests.class)
+public class GenotypePhenotypeSearchIT {
+
+    private static Client client = new Client(URLMAPPING.getInstance());
+
+    /**
+     * Ensure an error is thrown if no parameters are supplied.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void ensureCatchNoParametersSearch() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        final GAWrapperException didThrow =
+                catchGAWrapperException(() -> client.genotypePhenotype.searchGenotypePhenotype(request) );
+        assertThat(didThrow.getHttpStatusCode()).isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * Simple search for feature, searches by Genomic feature name.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void simpleFeatureSearch() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setFeature(TestData.FEATURE_NAME);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations()).isNotEmpty() ;
+    }
+
+    /**
+     * Simple search for evidence, searches by drug name.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void simpleEvidenceSearch() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setEvidence(TestData.EVIDENCE_NAME);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations()).isNotEmpty() ;
+    }
+
+    /**
+     * Checks that evidence level is present, searches by drug name.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void evidenceLevelCheck() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setFeature(TestData.FEATURE_NAME);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull();
+        assertThat(response.getAssociations()).isNotEmpty();
+        Evidence evidence = response.getAssociations().get(0).getEvidence().get(0);
+        assertThat(evidence.getEvidenceType().getTerm()).isEqualTo(TestData.EVIDENCE_LEVEL);
+    }
+
+    /**
+     * Simple search for Phenotype, searches by disease name.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void simplePhenotypeSearch() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setPhenotype(TestData.PHENOTYPE_NAME);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations()).isNotEmpty() ;
+    }
+
+    /**
+     * Simple search for Phenotype, using a non-existent, random disease name.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void simplePhenotypeSearchNoFind() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setPhenotype(Utils.randomName());
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations()).isEmpty();
+    }
+
+    /**
+     * Search for Feature , using for specific external identifier.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void simpleFeatureSearchExternalIdentifier() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        ExternalIdentifier id = new ExternalIdentifier() ;
+        id.setDatabase(TestData.FEATURE_DB);
+        id.setIdentifier(TestData.FEATURE_DB_ID);
+        id.setVersion(TestData.FEATURE_DB_VERSION);
+        List<ExternalIdentifier> ids = new ArrayList<>() ;
+        ids.add(id) ;
+        ExternalIdentifierQuery feature = new ExternalIdentifierQuery();
+        feature.setIds(ids);
+        request.setFeature(feature);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations().size()).isEqualTo(1);
+    }
+
+    /**
+     * Search for Phenotype , using specific external identifier.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void simplePhenotypeSearchExternalIdentifier() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        ExternalIdentifier id = new ExternalIdentifier() ;
+        id.setDatabase(TestData.PHENOTYPE_DB);
+        id.setIdentifier(TestData.PHENOTYPE_DB_ID);
+        id.setVersion(TestData.PHENOTYPE_DB_VERSION);
+        List<ExternalIdentifier> ids = new ArrayList<>() ;
+        ids.add(id) ;
+        ExternalIdentifierQuery phenotype = new ExternalIdentifierQuery();
+        phenotype.setIds(ids);
+        request.setPhenotype(phenotype);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations()).isNotEmpty() ;
+    }
+
+    /**
+     * Search for Evidence, using specific external identifier.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void simpleEvidenceSearchExternalIdentifier() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        ExternalIdentifier id = new ExternalIdentifier();
+        id.setDatabase(TestData.EVIDENCE_DB);
+        id.setIdentifier(TestData.EVIDENCE_DB_ID);
+        id.setVersion(TestData.EVIDENCE_DB_VERSION);
+        List<ExternalIdentifier> ids = new ArrayList<>();
+        ids.add(id) ;
+        ExternalIdentifierQuery evidence = new ExternalIdentifierQuery();
+        evidence.setIds(ids);
+        request.setEvidence(evidence);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull();
+        assertThat(response.getAssociations()).isNotEmpty();
+        Evidence evidenceObject = response.getAssociations().get(0).getEvidence().get(0);
+        assertThat(evidenceObject.getEvidenceType().getTerm()).isEqualTo(TestData.EVIDENCE_LEVEL);
+    }
+
+    /**
+     * Simple search for Feature, test page size = 1, expects a single result.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void testGenotypePhenotypeSearchFeaturePagingOne() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setFeature(TestData.FEATURE_NAME);
+        request.setPageSize(1);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response).isNotNull();
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations().size()).isEqualTo(1);
+    }
+
+    /**
+     * Simple search for Feature, test page size = null, expects more than one result in the page.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void testGenotypePhenotypeSearchFeaturePagingMore() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setFeature(TestData.FEATURE_NAME);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations().size()).isGreaterThan(1);
+    }
+
+    /**
+     * Simple search for Feature, test page size = 1, find all, expects a single result per page.
+     * @throws AvroRemoteException if there's an unanticipated error
+     */
+    @Test
+    public void testGenotypePhenotypeSearchFeaturePagingAll() throws AvroRemoteException {
+        SearchGenotypePhenotypeRequest request = SearchGenotypePhenotypeRequest.newBuilder().build();
+        request.setFeature(TestData.FEATURE_NAME);
+        request.setPageSize(1);
+        SearchGenotypePhenotypeResponse response = client.genotypePhenotype.searchGenotypePhenotype(request);
+        assertThat(response.getAssociations()).isNotNull() ;
+        assertThat(response.getAssociations().size()).isEqualTo(1);
+        while(response.getNextPageToken() != null) {
+            System.err.println(response.getNextPageToken()) ;
+            String previous_id = response.getAssociations().get(0).getId() ;
+            request = SearchGenotypePhenotypeRequest.newBuilder().build();
+            request.setFeature(TestData.FEATURE_NAME);
+            request.setPageSize(1);
+            request.setPageToken(response.getNextPageToken());
+            response = client.genotypePhenotype.searchGenotypePhenotype(request);
+            if (response.getNextPageToken() != null ) {
+                assertThat(response.getAssociations()).isNotEmpty();
+                assertThat(previous_id).isNotEqualTo(response.getAssociations().get(0).getId());
+            }
+        }
+    }
+
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/g2p/GenotypePhenotypeTestSuite.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/g2p/GenotypePhenotypeTestSuite.java
@@ -1,0 +1,24 @@
+package org.ga4gh.cts.api.g2p;
+
+import com.googlecode.junittoolbox.IncludeCategories;
+import com.googlecode.junittoolbox.SuiteClasses;
+import com.googlecode.junittoolbox.WildcardPatternSuite;
+
+import org.ga4gh.ctk.testcategories.CoreTests;
+import org.ga4gh.cts.api.datasets.DatasetsTests;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>This suite runs the tests in the "GenotypePhenotype" category.</p>
+ * <p>It uses the {@link WildcardPatternSuite} runner, so use <tt>com.googlecode.junittoolbox</tt>'s
+ * {@code @IncludeCategories} or {@code ExcludeCategories} to customize.</p>
+ * <p>If there are no tests categorized as {@code DatasetsTests} then you'll get
+ * a {@code NoTestsRemainException}</p>
+ *
+ * @author Brian Walsh
+ */
+@RunWith(WildcardPatternSuite.class)
+@IncludeCategories({CoreTests.class, GenotypePhenotypeTests.class})
+@SuiteClasses({"**/*IT.class", "**/*Test.class"})
+public class GenotypePhenotypeTestSuite {
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/g2p/GenotypePhenotypeTests.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/g2p/GenotypePhenotypeTests.java
@@ -1,0 +1,9 @@
+package org.ga4gh.cts.api.g2p;
+
+/**
+ * Marker interface for tests related to the GenotypePhenotype API.
+ *
+ * @author Brian Walsh
+ */
+public interface GenotypePhenotypeTests {  /* category marker */
+}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/g2p/package-info.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/g2p/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains g2p tests, test suite, and test category.
+ */
+package org.ga4gh.cts.api.g2p;

--- a/test-data/cgd-test.ttl
+++ b/test-data/cgd-test.ttl
@@ -1,0 +1,252 @@
+@prefix ns1: <http://purl.org/oban/> .
+@prefix ns2: <http://purl.obolibrary.org/obo/> .
+@prefix ns3: <http://purl.org/dc/elements/1.1/> .
+@prefix ns4: <http://biohackathon.org/resource/faldo#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix OBAN: <http://purl.org/oban/> .
+@prefix OBO: <http://purl.obolibrary.org/obo/> .
+@prefix DrugBank: <http://www.drugbank.ca/drugs/> .
+@prefix CGD: <http://ohsu.edu/cgd/> .
+@prefix faldo: <http://biohackathon.org/resource/faldo#> .
+
+<http://ohsu.edu/cgd/0531e5c5> a OBAN:association ;
+    OBO:RO_has_approval_status <http://ohsu.edu/cgd/489e03d2> ;
+    OBAN:association_has_object <http://ohsu.edu/cgd/1b6442aa> ;
+    OBAN:association_has_object_property OBO:RO_0002606 ;
+    OBAN:association_has_subject DrugBank:DB00619 .
+
+CGD:bed32b89 a OBAN:association ;
+    OBO:RO_has_approval_status CGD:dc7d284a ;
+    OBAN:association_has_object <http://ohsu.edu/cgd/9a0c7b6e> ;
+    OBAN:association_has_object_property OBO:RO_0002606 ;
+    OBAN:association_has_subject DrugBank:DB01254 .
+
+CGD:c2ed4da0 a OBAN:association ;
+    OBO:RO_has_approval_status CGD:c703f7ab ;
+    OBAN:association_has_object <http://ohsu.edu/cgd/37da8697> ;
+    OBAN:association_has_object_property OBO:RO_0002606 ;
+    OBAN:association_has_subject DrugBank:DB00398 .
+
+CGD:fae52a14 a OBAN:association ;
+    OBO:RO_has_approval_status <http://ohsu.edu/cgd/489e03d2> ;
+    OBAN:association_has_object CGD:bff18fe6 ;
+    OBAN:association_has_object_property OBO:RO_0002606 ;
+    OBAN:association_has_subject DrugBank:DB01268 .
+
+<http://ohsu.edu/cgd/489e03d2> a owl:Class ;
+    rdfs:label "late trials" .
+
+CGD:dc7d284a a owl:Class ;
+    rdfs:label "preclinical" .
+
+CGD:c703f7ab a owl:Class ;
+    rdfs:label "early trials" .
+
+<http://ohsu.edu/cgd/1b6442aa> a OBO:OMIM_606764 ;
+    rdfs:label "GIST with biomarker KIT  wild type no mutation" ;
+    OBO:RO_has_biomarker <http://ohsu.edu/cgd/27d2169c> .
+
+<http://ohsu.edu/cgd/9a0c7b6e> a OBO:OMIM_606764 ;
+    rdfs:label "GIST with biomarker KIT  wild type no mutation" ;
+    OBO:RO_has_biomarker CGD:d212cbf9 .
+
+<http://ohsu.edu/cgd/37da8697> a OBO:OMIM_606764 ;
+    rdfs:label "GIST with biomarker KIT  wild type no mutation" ;
+    OBO:RO_has_biomarker <http://ohsu.edu/cgd/4841bf74> .
+
+CGD:bff18fe6 a OBO:OMIM_606764 ;
+    rdfs:label "GIST with biomarker KIT  wild type no mutation" ;
+    OBO:RO_has_biomarker <http://ohsu.edu/cgd/24228ad6> .
+
+<http://ohsu.edu/cgd/27d2169c> a OBO:SO_0001059 ;
+    rdfs:label "KIT  wild type no mutation" ;
+    OBO:RO_0002200 <http://ohsu.edu/cgd/87752f6c> .
+
+<http://ohsu.edu/cgd/24228ad6> a OBO:SO_0001059 ;
+    rdfs:label "KIT  wild type no mutation" ;
+    OBO:RO_0002200 <http://ohsu.edu/cgd/87795e43> .
+
+<http://ohsu.edu/cgd/87752f6c> a OBO:OMIM_606764 ;
+    rdfs:label "GIST with decreased sensitivity to therapy" ;
+    OBO:BFO_0000159 CGD:decreased_sensitivity .
+
+<http://ohsu.edu/cgd/5c895709> a OBO:OMIM_606764 ;
+    rdfs:label "GIST with sensitivity to therapy" ;
+    OBO:BFO_0000159 CGD:sensitivity .
+
+<http://ohsu.edu/cgd/87795e43> a OBO:OMIM_606764 ;
+    rdfs:label "GIST with response to therapy" ;
+    OBO:BFO_0000159 CGD:response .
+
+OBO:OMIM_606764 a owl:Class ;
+    rdfs:label "GIST" ;
+    rdfs:subClassOf OBO:DOID_4 .
+
+CGD:d212cbf9 a OBO:SO_0001059 ;
+    rdfs:label "KIT  wild type no mutation" ;
+    OBO:RO_0002200 <http://ohsu.edu/cgd/5c895709> .
+
+<http://ohsu.edu/cgd/4841bf74> a OBO:SO_0001059 ;
+    rdfs:label "KIT  wild type no mutation" ;
+    OBO:RO_0002200 <http://ohsu.edu/cgd/505c855a> .
+
+DrugBank:DB00619 a owl:Class ;
+    rdfs:label "imatinib" ;
+    OBO:RO_0002606 <http://ohsu.edu/cgd/0348822e>,
+        <http://ohsu.edu/cgd/0663d7aa>,
+        <http://ohsu.edu/cgd/10027e2b>,
+        <http://ohsu.edu/cgd/1141037f>,
+        <http://ohsu.edu/cgd/16ed1e21>,
+        <http://ohsu.edu/cgd/1b49fa54>,
+        <http://ohsu.edu/cgd/1b6442aa>,
+        <http://ohsu.edu/cgd/3660373b>,
+        <http://ohsu.edu/cgd/396e17ca>,
+        <http://ohsu.edu/cgd/4387ad11>,
+        <http://ohsu.edu/cgd/49773dd9>,
+        <http://ohsu.edu/cgd/4c9df69d>,
+        <http://ohsu.edu/cgd/593ba90d>,
+        <http://ohsu.edu/cgd/61a0ae6e>,
+        <http://ohsu.edu/cgd/6200b434>,
+        <http://ohsu.edu/cgd/622f5d87>,
+        <http://ohsu.edu/cgd/66956de7>,
+        <http://ohsu.edu/cgd/6f842dcb>,
+        <http://ohsu.edu/cgd/6fe97f66>,
+        <http://ohsu.edu/cgd/782a5adf>,
+        <http://ohsu.edu/cgd/80857771>,
+        <http://ohsu.edu/cgd/829ecfe4>,
+        <http://ohsu.edu/cgd/83589dc1>,
+        <http://ohsu.edu/cgd/8d3ef6b9>,
+        CGD:a05b065c,
+        CGD:a28d6b63,
+        CGD:a52d56bd,
+        CGD:ad7fe4a2,
+        CGD:b0523fef,
+        CGD:b40a93d7,
+        CGD:b8059d5f,
+        CGD:b82bb601,
+        CGD:bd5ec05d,
+        CGD:c3f8dbe4,
+        CGD:c585206a,
+        CGD:c5e74da6,
+        CGD:cd634e7c,
+        CGD:cfa27e95,
+        CGD:cfaf14e7,
+        CGD:d467afaa,
+        CGD:d634d636,
+        CGD:daa8ce89,
+        CGD:de0c523d,
+        CGD:e4e2d39b,
+        CGD:ebd2e0a0,
+        CGD:ed09a007,
+        CGD:f1c0bea0,
+        CGD:f52055a9,
+        CGD:f5c5ae17,
+        CGD:fe0f3b26 ;
+    rdfs:subClassOf OBO:CHEBI_23888 .
+
+DrugBank:DB01254 a owl:Class ;
+    rdfs:label "dasatinib" ;
+    OBO:RO_0002606 <http://ohsu.edu/cgd/0270d49e>,
+        <http://ohsu.edu/cgd/06d1537a>,
+        <http://ohsu.edu/cgd/07be695d>,
+        <http://ohsu.edu/cgd/204c5c4d>,
+        <http://ohsu.edu/cgd/211a6bfd>,
+        <http://ohsu.edu/cgd/24fc6515>,
+        <http://ohsu.edu/cgd/312a7c01>,
+        <http://ohsu.edu/cgd/316ba70b>,
+        <http://ohsu.edu/cgd/37ba4794>,
+        <http://ohsu.edu/cgd/39b33923>,
+        <http://ohsu.edu/cgd/4214ffb0>,
+        <http://ohsu.edu/cgd/53477124>,
+        <http://ohsu.edu/cgd/5730ad5d>,
+        <http://ohsu.edu/cgd/5d496096>,
+        <http://ohsu.edu/cgd/60d258f3>,
+        <http://ohsu.edu/cgd/6339e561>,
+        <http://ohsu.edu/cgd/79c33766>,
+        <http://ohsu.edu/cgd/7b37c3d3>,
+        <http://ohsu.edu/cgd/7f7b6467>,
+        <http://ohsu.edu/cgd/80412f7f>,
+        <http://ohsu.edu/cgd/83c53f39>,
+        <http://ohsu.edu/cgd/85722ca9>,
+        <http://ohsu.edu/cgd/88afcbf8>,
+        <http://ohsu.edu/cgd/90988c75>,
+        <http://ohsu.edu/cgd/9a0c7b6e>,
+        <http://ohsu.edu/cgd/9a3b8f86>,
+        <http://ohsu.edu/cgd/9ec35520>,
+        CGD:a1313702,
+        CGD:a60218cf,
+        CGD:b0148c82,
+        CGD:b0a03037,
+        CGD:b12958da,
+        CGD:b5bacf6d,
+        CGD:c602b6f4,
+        CGD:caf00fdf,
+        CGD:cc04d9d5,
+        CGD:d006d388,
+        CGD:df43c04f,
+        CGD:ef8944b8,
+        CGD:f84840a9 ;
+    rdfs:subClassOf OBO:CHEBI_23888 .
+
+DrugBank:DB00398 a owl:Class ;
+    rdfs:label "sorafenib" ;
+    OBO:RO_0002606 <http://ohsu.edu/cgd/1165021d>,
+        <http://ohsu.edu/cgd/37da8697>,
+        <http://ohsu.edu/cgd/47b7a3ba>,
+        <http://ohsu.edu/cgd/7aca8eca>,
+        <http://ohsu.edu/cgd/7b12ee2a>,
+        <http://ohsu.edu/cgd/87cabd66>,
+        <http://ohsu.edu/cgd/8b978c84>,
+        <http://ohsu.edu/cgd/8f795083>,
+        <http://ohsu.edu/cgd/90fadb4d>,
+        CGD:a7b840b5,
+        CGD:acaf1e33,
+        CGD:af2fb811,
+        CGD:b8293b8b,
+        CGD:bb66b1e9,
+        CGD:bf53fae5,
+        CGD:c56941f8,
+        CGD:d90f6f8c,
+        CGD:f21e69ef,
+        CGD:f4b538b0 ;
+    rdfs:subClassOf OBO:CHEBI_23888 .
+
+DrugBank:DB01268 a owl:Class ;
+    rdfs:label "sunitinib" ;
+    OBO:RO_0002606 <http://ohsu.edu/cgd/11ba3f14>,
+        <http://ohsu.edu/cgd/202aab8b>,
+        <http://ohsu.edu/cgd/330fdb9d>,
+        <http://ohsu.edu/cgd/392fb86a>,
+        <http://ohsu.edu/cgd/3f99c173>,
+        <http://ohsu.edu/cgd/4da27469>,
+        <http://ohsu.edu/cgd/54039374>,
+        <http://ohsu.edu/cgd/5c4e4aa5>,
+        <http://ohsu.edu/cgd/5ea8d37b>,
+        <http://ohsu.edu/cgd/65b688b1>,
+        <http://ohsu.edu/cgd/71fe9f0f>,
+        <http://ohsu.edu/cgd/7e7ac65b>,
+        <http://ohsu.edu/cgd/86415d40>,
+        <http://ohsu.edu/cgd/88e4c778>,
+        <http://ohsu.edu/cgd/983a1528>,
+        CGD:bff18fe6,
+        CGD:c9ce40f4,
+        CGD:d8f69729,
+        CGD:d9a4077f,
+        CGD:e901ee1e,
+        CGD:f7303413 ;
+    rdfs:subClassOf OBO:CHEBI_23888 .
+
+CGD:d8c2d551 a OBO:SO_0001059,
+        OBO:SO_0001583,
+        owl:NamedIndividual ;
+    rdfs:label "KIT V559I, H687Y, T670, V654A, A829P, D816, N822, Y823D missense mutation" ;
+    faldo:location <http://www.monarchinitiative.org/_654654UniProtKB:P10721#P10721-1Region> ;
+    OBO:GENO_0000408 <http://www.ncbi.nlm.nih.gov/gene/3815> ;
+    OBO:GENO_reference_amino_acid "V" ;
+    OBO:GENO_results_in_amino_acid_change "A" ;
+    OBO:RO_0002200 <http://ohsu.edu/cgd/4c7ff2c7> ;
+    OBO:RO_0002205 <http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=CCDS&DATA=3496.1> .


### PR DESCRIPTION
Plucked the g2p changes into the latest compliance suite here and refactored ontology `name` to `term` where needed.

FWIW I was able to get 11/12 tests to pass based on https://github.com/ga4gh/server/pull/933

@bwalsh I believe you can close out your other pull request this will be the new starting point.

```
simpleEvidenceSearchExternalIdentifier	Failure	expected:<"[early] trials"> but was:<"[late] trials">
```