### PR TITLE
remove parent section and add back in old version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,16 +33,9 @@
         <module>dist</module>
     </modules>
 
-    <parent>
-        <artifactId>ctk-parent</artifactId>
-        <groupId>org.ga4gh</groupId>
-        <version>0.6.0a2</version>
-        <relativePath>parent</relativePath>
-    </parent>
-
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk</artifactId>
-<!--    <version>0.6.0a1</version>-->
+    <version>0.6.0a1</version>
     <packaging>pom</packaging>
 
     <organization>


### PR DESCRIPTION
mvn clean install failed on my version of maven (3.3.9) until I made these changes. However mvn 3.3.3 builds correctly. I figure that we want to move forward with he latest version of maven.