### PR TITLE
update checkSearchingAllReferencesReturnsWellFormed

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceSetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceSetsSearchIT.java
@@ -58,7 +58,8 @@ public class ReferenceSetsSearchIT {
 
         final List<ReferenceSet> sets = resp.getReferenceSets();
 
-        sets.stream().forEach(this::checkRefSetConstants);
+        sets.stream().forEach(set-> assertThat(set.getId()).isNotNull() );
+        sets.stream().forEach(set-> assertThat(set.getMd5checksum()).matches("[a-fA-F0-9]{32}") );
     }
 
     /**


### PR DESCRIPTION
The current test searches for all reference sets then checks they match the test data. This fails for servers with more than just the compliance data. 
This PR replaces the comparision to compliance data with checks that the id is not null and the md5 looks like an md5. 

Fixes #161