### PR TITLE
Fixed typo in FeatureSearchIT test

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/sequenceAnnotations/FeaturesSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/sequenceAnnotations/FeaturesSearchIT.java
@@ -75,7 +75,7 @@ public class FeaturesSearchIT implements CtkLogs {
     public void checkFeaturesSearchByParentId() throws AvroRemoteException {
         final long start = 0;
         final long end = 100000000;
-        final int expectedNumberOfFeatures = 20;
+        final int expectedNumberOfFeatures = 50;
 
         final String id = Utils.getFeatureSetId(client);
 


### PR DESCRIPTION
fixed incorrect return count in `FeatuesSearchIT` method `checkFeaturesSearchByParentId` from 20 to 50.