### PR TITLE
Fix checkExpectedNumberOfRnaQuantifications

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/rnaquantification/RnaQuantificationSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/rnaquantification/RnaQuantificationSearchIT.java
@@ -8,6 +8,7 @@ import org.ga4gh.ctk.transport.GAWrapperException;
 import org.ga4gh.ctk.transport.URLMAPPING;
 import org.ga4gh.ctk.transport.protocols.Client;
 import org.ga4gh.cts.api.TestData;
+import org.ga4gh.cts.api.Utils;
 
 import ga4gh.RnaQuantificationServiceOuterClass.SearchRnaQuantificationsRequest;
 import ga4gh.RnaQuantificationServiceOuterClass.SearchRnaQuantificationsResponse;
@@ -61,11 +62,12 @@ public class RnaQuantificationSearchIT {
      */
     @Test
     public void checkExpectedNumberOfRnaQuantifications() throws InvalidProtocolBufferException, UnirestException, GAWrapperException {
-        final int expectedNumberOfRnaQuantifications = 4;
-
+        final int expectedNumberOfRnaQuantifications = 1;
+        final String rnaQuantificationSetId = Utils.getRnaQuantificationSetId(client);
         final SearchRnaQuantificationsRequest req =
                 SearchRnaQuantificationsRequest.newBuilder()
                         .setDatasetId(TestData.getDatasetId())
+                        .setRnaQuantificationSetId(rnaQuantificationSetId)
                         .build();
         final SearchRnaQuantificationsResponse resp = client.rnaquantifications.searchRnaQuantification(req);
 


### PR DESCRIPTION
@saupchurch is there really only supposed to be 1 rnaQuantification loaded into the server in the current test_data dataset?