### PR TITLE
RNA Update

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/rnaquantification/ExpressionLevelsIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/rnaquantification/ExpressionLevelsIT.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -54,13 +56,14 @@ public class ExpressionLevelsIT {
      */
     @Test
     public void checkExpectedNumberOfExpressionLevels() throws InvalidProtocolBufferException, UnirestException, GAWrapperException {
-        final int expectedNumberOfExpressionLevels = 8;
+        final int expectedNumberOfExpressionLevels = 6;  // The threshold defaults to 0 and removes 2 values
         final String rnaQuantificationSetId = Utils.getRnaQuantificationSetId(client);
         final String rnaQuantificationId = Utils.getRnaQuantificationId(client, rnaQuantificationSetId);
 
         final SearchExpressionLevelsRequest req =
                 SearchExpressionLevelsRequest.newBuilder()
                         .setRnaQuantificationId(rnaQuantificationId)
+                        .setPageSize(100)
                         .build();
         final SearchExpressionLevelsResponse resp = client.rnaquantifications.searchExpressionLevel(req);
 

--- a/cts-java/src/test/java/org/ga4gh/cts/api/rnaquantification/ExpressionLevelsIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/rnaquantification/ExpressionLevelsIT.java
@@ -15,8 +15,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -56,7 +54,7 @@ public class ExpressionLevelsIT {
      */
     @Test
     public void checkExpectedNumberOfExpressionLevels() throws InvalidProtocolBufferException, UnirestException, GAWrapperException {
-        final int expectedNumberOfExpressionLevels = 4;
+        final int expectedNumberOfExpressionLevels = 8;
         final String rnaQuantificationSetId = Utils.getRnaQuantificationSetId(client);
         final String rnaQuantificationId = Utils.getRnaQuantificationId(client, rnaQuantificationSetId);
 

--- a/test-data/rna_control_file.tsv
+++ b/test-data/rna_control_file.tsv
@@ -1,2 +1,2 @@
 rna_quant_name	filename	type	feature_set_name	read_group_set_name	description	programs
-ENCFF786GKV	rna_brca1.tsv	rsem	gencodev19	ENCFF599WII	ENCODE test data from ENCSR000AEC	
+ENCFF786GKV	rna_brca1.tsv	rsem	gencodev19	HG00096	ENCODE test data from ENCSR000AEC	

--- a/test-data/rna_control_file.tsv
+++ b/test-data/rna_control_file.tsv
@@ -1,2 +1,2 @@
-rna_quant_id	filename	type	annotation_id	read_group_id	description	programs
-ENCFF786GKV	rna_brca1.tsv	rsem	hg19-V19	ENCFF599WII	ENCODE test data from ENCSR000AEC	
+rna_quant_name	filename	type	feature_set_name	read_group_set_name	description	programs
+ENCFF786GKV	rna_brca1.tsv	rsem	gencodev19	ENCFF599WII	ENCODE test data from ENCSR000AEC	


### PR DESCRIPTION
After fixing thresholds to be non-inclusive, expression entries with 0.0 were being removed from results. This PR changes the number of expected results to reflect the default threshold behavior.

Column titles in the test data were altered to reflect their meaning in the server (names, not IDs).