### PR TITLE
Change list reference bases from GET to POST

### DIFF
--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPINGImpl.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/URLMAPPINGImpl.java
@@ -66,7 +66,7 @@ public class URLMAPPINGImpl implements URLMAPPING {
         defaultEndpoints.put("ctk.tgt.getExpressionLevel", "expressionlevels/{id}");
         defaultEndpoints.put("ctk.tgt.getReferences", "references/{id}");
         defaultEndpoints.put("ctk.tgt.getReferenceSets", "referencesets/{id}");
-        defaultEndpoints.put("ctk.tgt.getReferencesBases", "references/{id}/bases");
+        defaultEndpoints.put("ctk.tgt.getReferencesBases", "listreferencebases");
         defaultEndpoints.put("ctk.tgt.getRnaQuantification", "rnaquantifications/{id}");
         defaultEndpoints.put("ctk.tgt.getRnaQuantificationSet", "rnaquantificationsets/{id}");
 

--- a/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
+++ b/ctk-transport/src/main/java/org/ga4gh/ctk/transport/protocols/Client.java
@@ -474,13 +474,9 @@ public class Client {
          * @throws UnirestException if there's a problem speaking HTTP to the server
          * @throws InvalidProtocolBufferException if there's a problem processing the JSON response from the server
          */
-        public ListReferenceBasesResponse getReferenceBases(String id, ListReferenceBasesRequest request) throws InvalidProtocolBufferException, UnirestException, GAWrapperException {
+        public ListReferenceBasesResponse getReferenceBases(ListReferenceBasesRequest request) throws InvalidProtocolBufferException, UnirestException, GAWrapperException {
             ListReferenceBasesResponse.Builder responseBuilder = ListReferenceBasesResponse.newBuilder();
-            final Map<String, Object> params = new HashMap<>();
-            putInMapIfValueNotNull(params, "start", request.getStart());
-            putInMapIfValueNotNull(params, "end", request.getEnd());
-            putInMapIfValueNotNull(params, "pageToken", request.getPageToken());
-            new Get<>(urls.getUrlRoot(), urls.getSearchReferenceBases(), id, params, responseBuilder, wireTracker).performQuery();
+            new Post<>(urls.getUrlRoot(), urls.getSearchReferenceBases(), request, responseBuilder, wireTracker).performQuery();
             return responseBuilder.build();
         }
     }

--- a/ctk-transport/src/main/resources/defaulttransport.properties
+++ b/ctk-transport/src/main/resources/defaulttransport.properties
@@ -13,7 +13,7 @@ ctk.tgt.searchVariants=variants/search
 ctk.tgt.searchCallsets=callsets/search
 ctk.tgt.getReferences=references/{id}
 ctk.tgt.getReferenceSets=referencesets/{id}
-ctk.tgt.getReferencesBases=references/{id}/bases
+ctk.tgt.getReferencesBases=listreferencebases
 
 ctk.tgt.getReadGroupSet=readgroupsets/{id}
 ctk.tgt.getReadGroup=readgroups/{id}

--- a/cts-java/pom.xml
+++ b/cts-java/pom.xml
@@ -55,6 +55,11 @@
             <!--</exclusions>-->
         </dependency>
         <dependency>
+            <groupId>com.github.ga4gh</groupId>
+            <artifactId>schemas</artifactId>
+            <version>${ga4gh.schema.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>

--- a/cts-java/src/main/resources/defaulttransport.properties
+++ b/cts-java/src/main/resources/defaulttransport.properties
@@ -13,7 +13,7 @@ ctk.tgt.searchVariants=variants/search
 ctk.tgt.searchCallsets=callsets/search
 ctk.tgt.getReferences=references/{id}
 ctk.tgt.getReferenceSets=referencesets/{id}
-ctk.tgt.getReferencesBases=references/{id}/bases
+ctk.tgt.getReferencesBases=listreferencebases
 
 ctk.tgt.getReadGroupSet=readgroupsets/{id}
 ctk.tgt.getReadGroup=readgroups/{id}

--- a/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceBasesPagingIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceBasesPagingIT.java
@@ -15,7 +15,7 @@ import org.junit.experimental.categories.Category;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test the <tt>/references/{id}/bases</tt> paging behavior.
+ * Test the <tt>/listreferencebases</tt> paging behavior.
  *
  * @author Herb Jellinek
  */
@@ -27,7 +27,7 @@ public class ReferenceBasesPagingIT {
     /**
      * Check that we can walk by single characters through the bases
      * we receive from
-     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(String, ListReferenceBasesRequest)}.
+     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(ListReferenceBasesRequest)}.
      *
      * @throws GAWrapperException if the server finds the request invalid in some way
      * @throws UnirestException if there's a problem speaking HTTP to the server
@@ -42,9 +42,10 @@ public class ReferenceBasesPagingIT {
         final long sequenceEnd = 15L;
 
         final ListReferenceBasesRequest req = ListReferenceBasesRequest.newBuilder()
+                .setReferenceId(refId)
                 .setStart(sequenceStart).setEnd(sequenceEnd)
                 .build();
-        final ListReferenceBasesResponse resp = client.references.getReferenceBases(refId, req);
+        final ListReferenceBasesResponse resp = client.references.getReferenceBases(req);
         final String expectedSequence = resp.getSequence();
         assertThat(expectedSequence).hasSize((int)(sequenceEnd - sequenceStart));
 
@@ -53,10 +54,11 @@ public class ReferenceBasesPagingIT {
         for (char expectedChar : expectedSequence.toCharArray()) {
             final ListReferenceBasesRequest pageReq =
                     ListReferenceBasesRequest.newBuilder()
-                                             .setStart(offset).setEnd(offset + 1)
-                                             .build();
+                            .setReferenceId(refId)
+                            .setStart(offset).setEnd(offset + 1)
+                            .build();
             final ListReferenceBasesResponse pageResp =
-                    client.references.getReferenceBases(refId, pageReq);
+                    client.references.getReferenceBases(pageReq);
             final String sequence = pageResp.getSequence();
             assertThat(sequence).hasSize(1);
             assertThat(sequence.charAt(0)).isEqualTo(expectedChar);
@@ -77,15 +79,16 @@ public class ReferenceBasesPagingIT {
         final String refId = Utils.getValidReferenceId(client);
 
         final ListReferenceBasesRequest req = ListReferenceBasesRequest.newBuilder()
-                                                                       .setStart(TestData.REFERENCE_START)
-                                                                       .build();
-        final ListReferenceBasesResponse resp = client.references.getReferenceBases(refId, req);
+                .setReferenceId(refId)
+                .setStart(TestData.REFERENCE_START)
+                .build();
+        final ListReferenceBasesResponse resp = client.references.getReferenceBases(req);
         return resp.getSequence();
     }
 
     /**
      * Check that we can request a sequence of bases from
-     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(String,
+     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(
      * ListReferenceBasesRequest)}
      * using a size equal to the size of the full sequence, and receive the full sequence.
      *
@@ -102,7 +105,7 @@ public class ReferenceBasesPagingIT {
 
     /**
      * Check that if we request a sequence of bases from
-     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(String,
+     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(
      * ListReferenceBasesRequest)}
      * using a size larger than the full sequence, it fails with an exception with HTTP status
      * "Requested Range Not Satisfiable."
@@ -132,7 +135,7 @@ public class ReferenceBasesPagingIT {
     /**
      * Check that we receive expected results when we request a single
      * chunk of bases from zero to <tt>chunkSize</tt> from
-     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(String,
+     * {@link org.ga4gh.ctk.transport.protocols.Client.References#getReferenceBases(
      * ListReferenceBasesRequest)}
      * using <tt>chunkSize</tt> as the sequence length.
      *
@@ -148,10 +151,11 @@ public class ReferenceBasesPagingIT {
         final long sequenceStart = 0L;
 
         final ListReferenceBasesRequest req = ListReferenceBasesRequest.newBuilder()
-                                                                       .setStart(sequenceStart)
-                                                                       .setEnd(chunkSize)
-                                                                       .build();
-        final ListReferenceBasesResponse resp = client.references.getReferenceBases(refId, req);
+                .setReferenceId(refId)
+                .setStart(sequenceStart)
+                .setEnd(chunkSize)
+                .build();
+        final ListReferenceBasesResponse resp = client.references.getReferenceBases(req);
         final String sequence = resp.getSequence();
         assertThat(sequence).isEqualTo(expectedSequence);
     }

--- a/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceBasesSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/references/ReferenceBasesSearchIT.java
@@ -83,11 +83,12 @@ public class ReferenceBasesSearchIT {
 
         final ListReferenceBasesRequest basesReq =
                 ListReferenceBasesRequest.newBuilder()
+                        .setReferenceId(ref.getId())
                         .setStart(start)
                         .setEnd(end)
                         .build();
         final ListReferenceBasesResponse basesResp =
-                client.references.getReferenceBases(ref.getId(), basesReq);
+                client.references.getReferenceBases(basesReq);
         assertThat(basesResp.getOffset()).isEqualTo(expectedOffset);
         assertThat(basesResp.getSequence()).isEqualTo(referenceBrcaSubsequence150To159);
     }


### PR DESCRIPTION
This PR changes the functionality of the list reference bases endpoint to a style more consistent with the remainder of the API. https://github.com/ga4gh/schemas/pull/647 https://github.com/ga4gh/server/pull/1309


* Reference ID's are now included directly in the request.
* The path for listing reference bases is simpler.

If the schemas are accepted the POM's need to be changed before this PR is merged.
