### PR TITLE
Unify properties for jitpack and version

### DIFF
--- a/ctk-cli/pom.xml
+++ b/ctk-cli/pom.xml
@@ -23,13 +23,13 @@
     <description>CLI app to drive tests of GA4GH data server v0.5.1</description>
 
     <artifactId>ctk-cli</artifactId>
-    <version>0.6.0a3</version>
+    <version>${compliance.version}</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.ga4gh</groupId>
         <artifactId>ctk-parent</artifactId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>../parent</relativePath>
     </parent>
     <!--
@@ -149,19 +149,14 @@
             <artifactId>bcel</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-testrunner</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
 
     </dependencies>

--- a/ctk-cli/src/main/resources/application.properties
+++ b/ctk-cli/src/main/resources/application.properties
@@ -31,7 +31,7 @@ ctk.antfile=lib/antRunTests.xml
 # which is already in "./lib"
 # when run from command line (doesn't currently affect output when running maven)
 # THIS IS A HACK FOR ANT, we should be scanning the lib dir (soon)
-ctk.testjar=cts-java-0.6.0a3-tests.jar
+ctk.testjar=cts-java-0.6.0a7-tests.jar
 
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)

--- a/ctk-cli/src/main/resources/ctk
+++ b/ctk-cli/src/main/resources/ctk
@@ -49,7 +49,7 @@ CMD_DIR="$(cd "$(dirname "$CMD")" && pwd -P)"
 # Defaults and command line options
 [ "$VERBOSE" ] ||  VERBOSE=
 [ "$DEBUG" ]   ||  DEBUG=
-[ "$CTKJAR" ]  ||  CTKJAR="ctk-cli-0.6.0a3.jar"
+[ "$CTKJAR" ]  ||  CTKJAR="ctk-cli-0.6.0a7.jar"
 [ "$TGTDIR" ] || TGTDIR="target"
 
 

--- a/ctk-domain/pom.xml
+++ b/ctk-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -16,14 +16,9 @@
 
     <dependencies>
         <dependency>
-            <!--TODO - make switch between local and github driven by config variable-->
-            <!--Uncomment to use local schema build-->
-            <!-- <groupId>org.ga4gh</groupId>
-            <artifactId>ga4gh-schemas</artifactId> -->
-            <!--Comment to use local schema build-->
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
+            <groupId>${ga4gh.schemas.groupId}</groupId>
+            <artifactId>${ga4gh.schemas.artifactId}</artifactId>
+            <version>${ga4gh.schemas.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -93,14 +88,9 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <!--TODO - make switch between local and github driven by config variable-->
-                                    <!--Uncomment to use local schema build-->
-                                    <!-- <groupId>org.ga4gh</groupId>
-                                    <artifactId>ga4gh-schemas</artifactId> -->
-                                    <!--Comment to use local schema build-->
-                                    <groupId>com.github.ga4gh</groupId>
-                                    <artifactId>schemas</artifactId>
-
+                                    <groupId>${ga4gh.schemas.groupId}</groupId>
+                                    <artifactId>${ga4gh.schemas.artifactId}</artifactId>
+>>>>>>> Unify properties for jitpack and version
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}/classes</outputDirectory>

--- a/ctk-server/pom.xml
+++ b/ctk-server/pom.xml
@@ -5,23 +5,22 @@
 
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk-server</artifactId>
-    <version>0.6.0a3</version>
+    <version>${compliance.version}</version>
     <packaging>jar</packaging>
 
     <name>CTK Web Server</name>
     <description>Server wrapper for CTK</description>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.0.M2</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <artifactId>ctk-parent</artifactId>
+        <groupId>org.ga4gh</groupId>
+        <version>${compliance.version}</version>
+        <relativePath>../parent</relativePath>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <ga4gh.schema.version>master-SNAPSHOT</ga4gh.schema.version>
         <ctk.tgt.urlRoot>http://localhost:8000</ctk.tgt.urlRoot>
 
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -30,7 +29,7 @@
         <ant.version>1.9.5</ant.version>
         <assertj.core.version>3.1.0</assertj.core.version>
         <assertj.generator.version>1.6.0</assertj.generator.version>
-        <bcel.version>6.0-SNAPSHOT</bcel.version>
+        <bcel.version>6.0</bcel.version>
         <gson.version>2.3.1</gson.version>
         <guava.version>18.0</guava.version>
         <httpasyncclient.version>4.1</httpasyncclient.version>
@@ -81,22 +80,17 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-testrunner</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.6.0a3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <!-- use tap4j to get Test Anything Protocol support -->
         <dependency>

--- a/ctk-server/src/main/resources/application.properties
+++ b/ctk-server/src/main/resources/application.properties
@@ -31,7 +31,7 @@ ctk.antfile=lib/antRunTests.xml
 # which is already in "./lib"
 # when run from command line (doesn't currently affect output when running maven)
 # THIS IS A HACK FOR ANT, we should be scanning the lib dir (soon)
-ctk.testjar=cts-java-0.6.0a3-tests.jar
+ctk.testjar=cts-java-0.6.0a7-tests.jar
 
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)

--- a/ctk-server/src/main/resources/ctk
+++ b/ctk-server/src/main/resources/ctk
@@ -49,7 +49,7 @@ CMD_DIR="$(cd "$(dirname "$CMD")" && pwd -P)"
 # Defaults and command line options
 [ "$VERBOSE" ] ||  VERBOSE=
 [ "$DEBUG" ]   ||  DEBUG=
-[ "$CTKJAR" ]  ||  CTKJAR="ctk-server-0.6.0a3.jar"
+[ "$CTKJAR" ]  ||  CTKJAR="ctk-server-0.6.0a7.jar"
 [ "$TGTDIR" ] || TGTDIR="target"
 
 

--- a/ctk-testrunner/pom.xml
+++ b/ctk-testrunner/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk-testrunner</artifactId>
-    <version>0.6.0a3</version>
+    <version>${compliance.version}</version>
     <name>CTK Test Runner</name>
     <description>Test-running module (not self-executable, requires a launcher)</description>
     <parent>
         <groupId>org.ga4gh</groupId>
         <artifactId>ctk-parent</artifactId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>../parent</relativePath>
     </parent>
 
@@ -105,15 +105,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <!-- lombok saves us some typing in the COnfig class -->
         <dependency>

--- a/ctk-testrunner/src/main/resources/application.properties
+++ b/ctk-testrunner/src/main/resources/application.properties
@@ -31,7 +31,7 @@ ctk.antfile=lib/antRunTests.xml
 # which is already in "./lib"
 # when run from command line (doesn't currently affect output when running maven)
 # THIS IS A HACK FOR ANT, we should be scanning the lib dir (soon)
-ctk.testjar=cts-java-0.6.0a3-tests.jar
+ctk.testjar=cts-java-0.6.0a7-tests.jar
 
 # this title (with ctk.tgt.urlRoot appended) goes on top of each HTML results page
 # when run from command line (doesn't currently affect output when running maven)

--- a/ctk-transport/pom.xml
+++ b/ctk-transport/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.ga4gh</groupId>
         <artifactId>ctk-parent</artifactId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -96,15 +96,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
 
         <!-- do we want to put slf4j-log4j12.jar on the path? or is OK it's supplied at runtime?-->

--- a/cts-demo-java/pom.xml
+++ b/cts-demo-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -16,22 +16,17 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-cli</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.6.0a3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
+            <version>${compliance.version}</version>
         </dependency>
         <!-- need BCEL during site build -->
         <dependency>

--- a/cts-java/pom.xml
+++ b/cts-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -16,48 +16,15 @@
     <packaging>jar</packaging>
 
     <dependencies>
-
-        <!--TODO - make switch between local and github driven by config variable
-        Currently, the maven build system relies on a github hosted schema.  This can be cumbersome
-        when implementing schema changes.  The ga4gh/schemas project has a maven project which will
-        install the schemas in the local maven repo at org.ga4gh.ga4gh-schemas.  By having a dependency
-        on org.ga4gh the build will use the artifact from the local repo.
-        -->
-        <!--Uncomment to use local schema build-->
-        <!--<dependency>-->
-        <!--<groupId>org.ga4gh</groupId>-->
-        <!--<artifactId>ga4gh-schemas</artifactId>-->
-        <!--<version>${ga4gh.schema.version}</version>-->
-        <!--</dependency>-->
-
-        <!--Comment to use local schema build-->
-        <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-domain</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-transport</artifactId>
-            <version>0.6.0a3</version>
-            <!--Uncomment to use local schema build-->
-            <!--<exclusions>-->
-                <!--<exclusion>  &lt;!&ndash; declare the exclusion here &ndash;&gt;-->
-                    <!--<groupId>com.github.ga4gh</groupId>-->
-                    <!--<artifactId>schemas</artifactId>-->
-                <!--</exclusion>-->
-            <!--</exclusions>-->
-        </dependency>
-        <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>../parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -26,23 +26,23 @@
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-cli</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>ctk-server</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ga4gh</groupId>
             <artifactId>cts-java</artifactId>
-            <version>0.6.0a3</version>
+            <version>${compliance.version}</version>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>com.github.ga4gh</groupId>
-            <artifactId>schemas</artifactId>
-            <version>${ga4gh.schema.version}</version>
+            <groupId>${ga4gh.schemas.groupId}</groupId>
+            <artifactId>${ga4gh.schemas.artifactId}</artifactId>
+            <version>${ga4gh.schemas.version}</version>
         </dependency>
     </dependencies>
 

--- a/docs/ConfigTheCTK.md
+++ b/docs/ConfigTheCTK.md
@@ -16,7 +16,7 @@ You can configure the CTK via the properties used by the:
 If you're working with CTK/CTS source (in an IDE or for a Maven build) it's easiest to just edit `ctk-cli/src/main/resources/application.properties`, `ctk-server/src/main/resources/application.properties`, and `ctk-testrunner/src/main/resources/application.properties`, but these changes will have no effect until you rebuild (because the rebuild copies the files from `src/main/resources/` into `target/` which is where the code runs from). But, you can make temporary changes to the text properties files directly in the output build `target` tree.
 
 If you're working with the CTK/CTS at the command line, you can extract that file from the packaged jar file and have it in the dir where the jar runs from
-(`jar xvf ctk-cli-v.0.6.0a3.jar application.properties`) ... if you're using the ZIP distribution, it will already have extracted that properties file (and other control files) for you.
+(`jar xvf ctk-cli-v.0.6.0a7.jar application.properties`) ... if you're using the ZIP distribution, it will already have extracted that properties file (and other control files) for you.
 
 Note that individual test suites (`cts-java` etc) might have individual configuration mechanisms or properties files - refer to their documentation.
 
@@ -41,7 +41,7 @@ The Properties list is available by looking at the javadoc for the `ctk-testrunn
 
 Because URLMAPPING initialization is a static action which might happen without logs being available, the URLMAPPING class has a special Java system property property to cause it to dump all the static initialization actions directly to stdout:
 
-`java -Dctk.tgt.urlmapper.dump=true -jar ctk-cli-0.6.0a3.jar`
+`java -Dctk.tgt.urlmapper.dump=true -jar ctk-cli-0.6.0a7.jar`
 
 Note that many tests reinitialize the URLMAPPER in a @BeforeClass, so you may see the initialization get dumped multiple times!
 
@@ -70,7 +70,7 @@ To set properties as a command line variable (the highest priority) for a Maven 
 ### Configuring a Command Line invocation
 From the directory where the executable jar is, you can edit `application.properties`. The zip distribution has this file pre-extracted, but if you don't already have it, just extract it from the executable jar like this
 
-    jar xvf ctk-cli-0.6.0a3.jar application.properties
+    jar xvf ctk-cli-0.6.0a7.jar application.properties
 
 Edit the properties file, and leave it in the launch directory or put it in a `config` subdirectory.
 

--- a/docs/README-Server.txt
+++ b/docs/README-Server.txt
@@ -1,14 +1,14 @@
 This is an experimental web-server wrapper for the GA4GH Conformance Test Kit (CTK).
 
 Run it using the included 'ctk' script, or simply as
-    java -jar ctk-server-0.6.0a3.jar
+    java -jar ctk-server-0.6.0a7.jar
 
 Once it is running, it exposes a server at port 8080. (Being a Spring Boot app,
 you can modify the port number with the normal --server.port= ... setting, like this:
 
    ./ctk --server.port=8088
    or
-   java -jar ctk-server-0.6.0a3.jar --server.port=8088
+   java -jar ctk-server-0.6.0a7.jar --server.port=8088
 
 To run the tests, you just browse to that server using a web browser; it
 will run using the defaults and values set in the application properties file.

--- a/docs/RunningTests_maven.md
+++ b/docs/RunningTests_maven.md
@@ -122,7 +122,7 @@ processes):
     2. edit `application-properties` (or set environment properties) to point to the in-source location of files, for example:
         1. `ctk.antfile=../ctk-testrunner/src/main/resources/antRunTests.xml`
         2. `ctk.defaulttransportfile=../ctk-transport/src/main/resources/defaulttransport.properties/defaulttransport.properties`
-        3. `ctk.testjar=../cts-java/target/cts-java-0.6.0a3-tests.jar`
+        3. `ctk.testjar=../cts-java/target/cts-java-0.6.0a7-tests.jar`
         4. `ctk.testclassroots=../cts-java/target/test-classes`
         5. `ctk.domaintypesfile=../ctk-domain/src/main/resources/avro-types.json`
     2. manually create a `ctk-cli/lib` directory and copy into it the logging control file(s) from

--- a/docs/UpdatingTheSchemas.md
+++ b/docs/UpdatingTheSchemas.md
@@ -1,82 +1,17 @@
 # Updating the Schemas
 
-When the [schemas](http://github.com/ga4gh/schemas) change, so must the The Compliance Test Kit.  It does not automatically
-sync with the [Schemas repo](http://github.com/ga4gh/schemas); we do that by hand.
+This software uses [jitpack](https://jitpack.io) to allow the GA4GH schemas repository to be added as a maven dependency. By default, the current schemas on the GA4GH github `master` branch.
 
-This is a quick description of the steps to follow to update the schemas contained in the test kit, and then to
-update the tests and test infrastructure to match.
+This setting can be overridden by editing `parent/pom.xml`. To point to a personal fork, simply change the line for the dependencies `groupId`.
 
-## Assumptions
+        <ga4gh.schemas.groupId>com.github.ga4gh</ga4gh.schemas.groupId>
 
-We assume the following:
+Will then become:
 
-- You have a local copy of the `ga4gh/schemas` repository stored in a local directory called
-`schemas`.
+        <ga4gh.schemas.groupId>com.github.david4096</ga4gh.schemas.groupId>
 
-- Your working copy of the Compliance Test Kit is stored in the directory `compliance`.
+Which points to the user `david4096`, instead of the GA4GH organization's fork. To use a specific branch from that fork, change the next property, `schemas.version`, to point at the branch name appended by the string "-SNAPSHOT".
 
-- You're using a Unixesque shell (command interpreter).
+        <ga4gh.schemas.version>dev-SNAPSHOT</ga4gh.schemas.version>
 
-- You have the [Maven](https://maven.apache.org/) command line program `mvn` installed.
-
-## Procedure
-
-### Install the Maven command line program
-
-If necessary, install Maven.  Execute this command to see if you already have it:
-
-    $ which mvn
-
-If the `which` program produces any output (e.g. `/usr/local/bin/mvn`), it's installed.  Otherwise...
-
-On OS X, you can use Brew to do it:
-
-    $ brew install maven
-
-On Ubuntu:
-
-    $ sudo apt-get install maven
-
-On Fedora/Redhat:
-
-    $ sudo yum install maven
-
-### Replace the Schema Files
-
-Remove all old schema (`.avdl`) files from the compliance project:
-
-    $ rm compliance/ctk-schemas/src/main/resources/avro/*.avdl
-
-Copy the new schema files from `schemas` to `compliance`:
-
-    $ cp schemas/src/main/resources/avro/*.avdl compliance/ctk-schemas/src/main/resources/avro
-
-### Clean the `compliance` project
-
-Change directories to the root of the `compliance` project and remove all compiled output.
-
-    $ cd compliance
-    $ mvn clean
-
-### Pull in project dependencies
-
-    $ (cd parent; mvn install)
-
-### Remove the source code generated for the previous Schemas version and generate it again
-
-    $ (cd ctk-schemas; mvn clean && mvn install)
-
-### Build everything!
-
-If everything went well in the previous steps, you're ready to compile the tests.  This is when you discover
-how the changes have affected the tests.
-
-    $ mvn package
-
-## Summary
-
-We detailed the steps required to update the schemas and compile the Compliance Test Kit.
-
-We did __not__ discuss how to handle the effects of the many different types of schema changes, as that's well
-beyond the scope of this document.
-
+This functionality can also be used to point to specific commit hashes or releases. For more information visit [jitpack](https://jitpack.io).

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk-parent</artifactId>
-    <version>0.6.0a3</version>
+    <version>${compliance.version}</version>
 
     <packaging>pom</packaging>
 
@@ -29,11 +29,22 @@
 
 
     <properties>
-        <ga4gh.schema.version>master-SNAPSHOT</ga4gh.schema.version>
+        <compliance.version>0.6.0a7</compliance.version>
+        <!--
+          Use this section to indicate the repository and branch of schemas
+          your tests will be compiled against.
+          To use your own version of the schemas, change the groupId to your
+          github account (e.g. com.github.david4096).
+          Then change the schemas.version to be the commit hash, release, 
+          or branch snapshot you would like to test.
+        -->
+        <ga4gh.schemas.groupId>com.github.ga4gh</ga4gh.schemas.groupId>
+        <ga4gh.schemas.version>master-SNAPSHOT</ga4gh.schemas.version>
+        <ga4gh.schemas.artifactId>schemas</ga4gh.schemas.artifactId>
         <ctk.tgt.urlRoot>http://localhost:8000</ctk.tgt.urlRoot>
         <!-- Controls skipping of cts-java IT tests during build; skip the tests by passing
              a command line parameter, e.g. mvn -Dcts.skipITs=true install.  Run them by default. -->
-        <cts.skipITs>false</cts.skipITs>
+        <cts.skipITs>true</cts.skipITs>
 
         <java.version>1.8</java.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -239,7 +250,7 @@
             <dependency>
                 <groupId>com.github.ga4gh</groupId>
                 <artifactId>schemas</artifactId>
-                <version>${ga4gh.schema.version}</version>
+                <version>${ga4gh.schemas.version}</version>
             </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,17 +31,16 @@
         <module>ctk-server</module>
         <module>dist</module>
     </modules>
-
     <parent>
         <artifactId>ctk-parent</artifactId>
         <groupId>org.ga4gh</groupId>
-        <version>0.6.0a3</version>
+        <version>${compliance.version}</version>
         <relativePath>parent</relativePath>
     </parent>
 
     <groupId>org.ga4gh</groupId>
     <artifactId>ctk</artifactId>
-<!--    <version>0.6.0a3</version>-->
+    <version>${compliance.version}</version>
     <packaging>pom</packaging>
 
     <organization>

--- a/test-data/rna_control_file.tsv
+++ b/test-data/rna_control_file.tsv
@@ -1,2 +1,0 @@
-rna_quant_name	filename	type	feature_set_name	read_group_set_name	description	programs
-ENCFF786GKV	rna_brca1.tsv	rsem	gencodev19	HG00096	ENCODE test data from ENCSR000AEC	


### PR DESCRIPTION
The important hand edited properties are now editable in one place (parent/pom.xml).

The schema version was being set in multiple places. Added a brief comment that explains how to switch to your own repo for schemas. Place the versioning in a single property so it is reused throughout.
Add docs for usage

Pushes version to 0.6.0a7 and adds version as property of parent/pom.xml.
@bwalsh 