### PR TITLE
added timestamps to dataset metadata

### DIFF
--- a/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/TestData.java
@@ -164,6 +164,16 @@ public class TestData {
     public static final String INDIVIDUAL_NAME = "HG00096";
 
     /**
+     * The creation DateTime in the test data.
+     */
+    public static final String CREATE_DATETIME = "2008-04-25T18:30:00+00:00";
+
+    /**
+     * The update DateTime in the test data.
+     */
+    public static final String UPDATE_DATETIME = "2016-05-15T17:34:00-01:00";
+
+    /**
      * Return the ID of the compliance dataset on the server being tested.
      * By default this is the value of {@link #DEFAULT_DATASET_ID}, but
      * you can override it by setting the Java property <tt>-Dctk.tgt.dataset_id</tt>.

--- a/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/datasets/DatasetsSearchIT.java
@@ -64,6 +64,22 @@ public class DatasetsSearchIT {
     }
 
     /**
+     * Check that we can retrieve the compliance dataset creation and update
+     * datetimes </tt>.
+     *
+     * @throws GAWrapperException if the server finds the request invalid in some way
+     * @throws UnirestException if there's a problem speaking HTTP to the server
+     * @throws InvalidProtocolBufferException if there's a problem processing the JSON response from the server
+     */
+    @Test
+    public void checkDatasetDateTimes() throws InvalidProtocolBufferException, UnirestException, GAWrapperException {
+        final Dataset dataset = client.metadata.getDataset(TestData.getDatasetId());
+        assertThat(dataset).isNotNull();
+        assertThat(dataset.getCreateDateTime()).isEqualTo(TestData.CREATE_DATETIME);
+        assertThat(dataset.getUpdateDateTime()).isEqualTo(TestData.UPDATE_DATETIME);
+    }
+
+    /**
      * Try to fetch a dataset with a bogus ID and make sure it fails.
      */
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")

--- a/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsSearchIT.java
+++ b/cts-java/src/test/java/org/ga4gh/cts/api/variants/VariantsSearchIT.java
@@ -149,7 +149,8 @@ public class VariantsSearchIT implements CtkLogs {
         final SearchVariantsResponse vResp = client.variants.searchVariants(vReq);
         final List<Variant> searchVariants = vResp.getVariantsList();
 
-        checkAllCalls(searchVariants, c -> assertThat(c.getGenotypeList()).isNotNull().isNotEmpty());
+        checkAllCalls(searchVariants, c -> assertThat(c.getGenotype()).isNotNull());
+        checkAllCalls(searchVariants, c -> assertThat(c.getGenotype().getValuesList()).isNotEmpty());
         checkAllCalls(searchVariants, c -> assertThat(c.getGenotypeLikelihoodList()).isNotNull());
         checkAllCalls(searchVariants, c -> {
             assertThat(c.getInfo()).isNotNull();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -38,8 +38,8 @@
           Then change the schemas.version to be the commit hash, release, 
           or branch snapshot you would like to test.
         -->
-        <ga4gh.schemas.groupId>com.github.ga4gh</ga4gh.schemas.groupId>
-        <ga4gh.schemas.version>master-SNAPSHOT</ga4gh.schemas.version>
+        <ga4gh.schemas.groupId>com.github.ejacox</ga4gh.schemas.groupId>
+        <ga4gh.schemas.version>626_timestamps-SNAPSHOT</ga4gh.schemas.version>
         <ga4gh.schemas.artifactId>schemas</ga4gh.schemas.artifactId>
         <ctk.tgt.urlRoot>http://localhost:8000</ctk.tgt.urlRoot>
         <!-- Controls skipping of cts-java IT tests during build; skip the tests by passing


### PR DESCRIPTION
Create and update timestamps were added to the dataset message in the metadata proto. See issue ga4gh/schemas#626.