### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # CTK
-An extensible Conformance Test Kit for the GA4GH Server API.
+An extensible Conformance Test Kit for the GA4GH Server API. 
+
+#THIS REPOSITORY HAS BEEN DEPRECATED FOR NEW WORK
+
+Due to a GA4GH move to produce smaller, tightly defined, standards in smaller bites, this repository is no longer suitable as a place for new standards to be added. If further work is required on an existing schema defined within this repository the recommendation is to extract that schema from within this repo and work on it in a separate space. Please see the GA4GH website <https://ga4gh.org> for further details on the GA4GH Connect operational structure (which includes details on Work Streams), lists of existing standards and contact details should you have further queries. 
 
 ## Build Status
 


### PR DESCRIPTION
At a GA4GH Meeting it was decided to halt work on the Reference Server Implementation